### PR TITLE
Add plans support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.9.0
+
+  Add support for plans - accessible via the Site
+
 ## 0.7.1
 
   Improve change detection speed

--- a/kibble/api/plans.go
+++ b/kibble/api/plans.go
@@ -1,0 +1,82 @@
+//    Copyright 2018 SHIFT72
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/gosimple/slug"
+	"github.com/indiereign/shift72-kibble/kibble/models"
+)
+
+// LoadAllPlans - loads all active plans
+func LoadAllPlans(cfg *models.Config, site *models.Site, itemIndex models.ItemIndex) error {
+
+	path := fmt.Sprintf("%s/services/pricing/v1/plans", cfg.SiteURL)
+	data, err := Get(cfg, path)
+	if err != nil {
+		return err
+	}
+
+	var apiPlans []PlansV1
+	err = json.Unmarshal([]byte(data), &apiPlans)
+	if err != nil {
+		return err
+	}
+
+	for _, b := range apiPlans {
+		n := b.mapToModel(site.Config, itemIndex)
+
+		// link to the page if it exists
+		if p, ok := site.Pages.FindPageByID(b.PageID); ok {
+			n.Page = p
+		}
+
+		site.Plans = append(site.Plans, n)
+	}
+
+	return nil
+}
+
+func (p PlansV1) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.ItemIndex) models.Plan {
+	return models.Plan{
+		ID:              p.ID,
+		Slug:            fmt.Sprintf("/plan/%d", p.ID),
+		NameSlug:        slug.Make(p.Name),
+		Name:            p.Name,
+		Description:     p.Description,
+		Interval:        p.Interval,
+		IntervalCount:   p.IntervalCount,
+		TrialPeriodDays: p.TrialPeriodDays,
+		CreatedAt:       p.CreatedAt,
+		UpdatedAt:       p.UpdatedAt,
+	}
+}
+
+// PlansV1 - model
+type PlansV1 struct {
+	ID              int       `json:"id"`
+	Name            string    `json:"name"`
+	Description     string    `json:"description"`
+	Status          string    `json:"status"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+	PageID          int       `json:"page_id"`
+	Interval        *string   `json:"interval"`
+	IntervalCount   *int      `json:"interval_count"`
+	TrialPeriodDays *int      `json:"trial_period_days"`
+}

--- a/kibble/api/plans_test.go
+++ b/kibble/api/plans_test.go
@@ -1,0 +1,71 @@
+//    Copyright 2018 SHIFT72
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/indiereign/shift72-kibble/kibble/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlansMapping(t *testing.T) {
+
+	itemIndex := make(models.ItemIndex)
+
+	serviceConfig := commonServiceConfig()
+
+	apiPlan := PlansV1{
+		Name:        "Bronze Plan",
+		Description: "Plan description",
+		Status:      "active",
+	}
+
+	model := apiPlan.mapToModel(serviceConfig, itemIndex)
+
+	assert.Equal(t, "Bronze Plan", model.Name)
+	assert.Equal(t, "bronze-plan", model.NameSlug)
+	assert.Equal(t, "Plan description", model.Description)
+	assert.Nil(t, model.Interval)
+}
+
+func TestPlansMappingWithOptionalSvodFields(t *testing.T) {
+
+	itemIndex := make(models.ItemIndex)
+
+	serviceConfig := commonServiceConfig()
+
+	interval := "week"
+	intervalCount := 4
+	trialPeriodDays := 7
+
+	apiPlan := PlansV1{
+		Name:            "Bronze Plan",
+		Description:     "Plan description",
+		Status:          "active",
+		Interval:        &interval,
+		IntervalCount:   &intervalCount,
+		TrialPeriodDays: &trialPeriodDays,
+	}
+
+	model := apiPlan.mapToModel(serviceConfig, itemIndex)
+
+	assert.Equal(t, "Bronze Plan", model.Name)
+	assert.Equal(t, "bronze-plan", model.NameSlug)
+	assert.Equal(t, "Plan description", model.Description)
+	assert.Equal(t, &interval, model.Interval)
+	assert.Equal(t, &intervalCount, model.IntervalCount)
+	assert.Equal(t, &trialPeriodDays, model.TrialPeriodDays)
+}

--- a/kibble/api/site.go
+++ b/kibble/api/site.go
@@ -45,15 +45,17 @@ func LoadSite(cfg *models.Config) (*models.Site, error) {
 	}
 
 	site := &models.Site{
-		SiteConfig:  cfg,
-		Config:      config,
-		Toggles:     toggles,
-		Languages:   sortLanguages(cfg),
-		Navigation:  navigation,
-		Pages:       pages,
-		Films:       make(models.FilmCollection, 0),
+		SiteConfig: cfg,
+		Config:     config,
+		Toggles:    toggles,
+		Languages:  sortLanguages(cfg),
+		Navigation: navigation,
+
 		Bundles:     make(models.BundleCollection, 0),
 		Collections: make(models.CollectionCollection, 0),
+		Films:       make(models.FilmCollection, 0),
+		Pages:       pages,
+		Plans:       make(models.PlanCollection, 0),
 		Taxonomies:  make(models.Taxonomies),
 		TVShows:     make(models.TVShowCollection, 0),
 		TVSeasons:   make(models.TVSeasonCollection, 0),
@@ -70,6 +72,11 @@ func LoadSite(cfg *models.Config) (*models.Site, error) {
 	}
 
 	err = LoadAllBundles(cfg, site, itemIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	err = LoadAllPlans(cfg, site, itemIndex)
 	if err != nil {
 		return nil, err
 	}

--- a/kibble/models/api.go
+++ b/kibble/models/api.go
@@ -34,6 +34,7 @@ type Site struct {
 	TVSeasons   TVSeasonCollection
 	Bundles     BundleCollection
 	Collections CollectionCollection
+	Plans       PlanCollection
 	Taxonomies  Taxonomies
 }
 

--- a/kibble/models/plans.go
+++ b/kibble/models/plans.go
@@ -1,0 +1,35 @@
+//    Copyright 2018 SHIFT72
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package models
+
+import "time"
+
+// PlanCollection is a list of published plans
+type PlanCollection []Plan
+
+// Plan -
+type Plan struct {
+	ID              int
+	Slug            string
+	Name            string
+	NameSlug        string
+	Description     string
+	Interval        *string
+	IntervalCount   *int
+	TrialPeriodDays *int
+	Page            *Page
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}


### PR DESCRIPTION
Add support for plans
Accessible via the site.

Data Sources are not implemented as I wonder if these will get used.