### PR TITLE
actually support ints in template i18n function

### DIFF
--- a/kibble/models/template.go
+++ b/kibble/models/template.go
@@ -71,19 +71,17 @@ func CreateTemplateView(routeRegistry *RouteRegistry, trans i18n.TranslateFunc, 
 			       Count field must be an integer type (int, int8, int16, int32, int64) or a float formatted as a string (e.g. "123.45").
 		*/
 		if len(args) == 1 {
+			argType := reflect.TypeOf(args[0]).Name()
+
+			if argType == "string" || strings.Contains(argType, "int") || argType == "map[string]interface {}" {
+				return trans(translationID, args[0])
+			}
+
 			if f, ok := args[0].(float64); ok {
 				return trans(translationID, int(f))
 			}
 
-			if s, ok := args[0].(string); ok {
-				return trans(translationID, s)
-			}
-
-			if m, ok := args[0].(map[string]interface{}); ok {
-				return trans(translationID, m)
-			}
-
-			log.Errorf("WARN: translating %s found unrecognised type %s", translationID, reflect.TypeOf(args[0]))
+			log.Errorf("WARN: translating %s found unrecognised type %s", translationID, argType)
 		}
 		return trans(translationID)
 	})


### PR DESCRIPTION
The i18n library allows ints as a parameter but the i18n template function previously ignored them.
It now lets any type containing "int" through.

There might be a better way of doing this, but I didn't want to go through all the "int" possibilites and try casting each one.