### PR TITLE
Season Bonus Content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ kibble-npm/node_modules
 kibble-npm/bin
 s72-kibble-*
 kibble-windows-amd64.exe
+.vs

--- a/kibble/api/bonus_content.go
+++ b/kibble/api/bonus_content.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/indiereign/shift72-kibble/kibble/models"
+	"github.com/indiereign/shift72-kibble/kibble/utils"
+)
+
+// bonusContentV2 - bonus content model
+type bonusContentV2 struct {
+	Number    int     `json:"number"`
+	Title     string  `json:"title"`
+	Overview  string  `json:"description"`
+	Runtime   float64 `json:"runtime"`
+	ImageUrls struct {
+		Portrait       string `json:"portrait"`
+		Landscape      string `json:"landscape"`
+		Header         string `json:"header"`
+		Carousel       string `json:"carousel"`
+		Bg             string `json:"bg"`
+		Classification string `json:"classification"`
+	} `json:"image_urls"`
+	Subtitles []subtitleTrackV1 `json:"subtitle_tracks"`
+}
+
+func (bcv2 bonusContentV2) mapToModel2(parentSlug string, parentImages models.ImageSet) models.BonusContent {
+
+	b := models.BonusContent{
+		Slug:     fmt.Sprintf("%s/bonus/%d", parentSlug, bcv2.Number),
+		Number:   bcv2.Number,
+		Title:    bcv2.Title,
+		Runtime:  models.Runtime(bcv2.Runtime),
+		Overview: bcv2.Overview,
+		Images: models.ImageSet{
+			Portrait:       utils.Coalesce(bcv2.ImageUrls.Portrait, parentImages.Portrait),
+			Landscape:      utils.Coalesce(bcv2.ImageUrls.Landscape, parentImages.Landscape),
+			Header:         utils.Coalesce(bcv2.ImageUrls.Header, parentImages.Header),
+			Carousel:       utils.Coalesce(bcv2.ImageUrls.Carousel, parentImages.Carousel),
+			Background:     utils.Coalesce(bcv2.ImageUrls.Bg, parentImages.Background),
+			Classification: utils.Coalesce(bcv2.ImageUrls.Classification, parentImages.Classification),
+		},
+	}
+
+	for _, t := range bcv2.Subtitles {
+		b.Subtitles = append(b.Subtitles, models.SubtitleTrack{
+			Language: t.Language,
+			Name:     t.Name,
+			Type:     t.Type,
+			Path:     t.Path,
+		})
+	}
+
+	return b
+
+}

--- a/kibble/api/bonus_content_test.go
+++ b/kibble/api/bonus_content_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/indiereign/shift72-kibble/kibble/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBonusContentSubtitlesModelSupport(t *testing.T) {
+	apiBonus := bonusContentV2{
+		Subtitles: []subtitleTrackV1{{
+			Language: "it",
+			Name:     "Italian",
+			Type:     "caption",
+			Path:     "/subtitles/film/49/bonus/1/it/caption-18.vtt",
+		}},
+	}
+
+	model := apiBonus.mapToModel2("/film/1", models.ImageSet{
+		Portrait: "film-portrait",
+	})
+
+	assert.Equal(t, 1, len(model.Subtitles), "expect the subtitles to be 1")
+	assert.Equal(t, "it", model.Subtitles[0].Language)
+	assert.Equal(t, "Italian", model.Subtitles[0].Name)
+	assert.Equal(t, "caption", model.Subtitles[0].Type)
+	assert.Equal(t, "/subtitles/film/49/bonus/1/it/caption-18.vtt", model.Subtitles[0].Path)
+}
+
+func TestBonusContentImagesUseFilmImagesAsFallback(t *testing.T) {
+
+	itemIndex := make(models.ItemIndex)
+
+	serviceConfig := commonServiceConfig()
+
+	apiFilm := filmV2{
+		ID:      123,
+		Title:   "Film One",
+		Slug:    "/film/52",
+		Tagline: "Tag line",
+		Runtime: 123,
+		Bonuses: []bonusContentV2{{
+			Number: 1,
+			Title:  "Behind the scenes",
+		}},
+		ImageUrls: struct {
+			Portrait       string `json:"portrait"`
+			Landscape      string `json:"landscape"`
+			Header         string `json:"header"`
+			Carousel       string `json:"carousel"`
+			Bg             string `json:"bg"`
+			Classification string `json:"classification"`
+		}{
+			Portrait:       "film-portrait.jpeg",
+			Landscape:      "film-landscape.jpeg",
+			Header:         "film-header.jpeg",
+			Carousel:       "film-carousel.jpeg",
+			Bg:             "film-background.jpeg",
+			Classification: "film-classification.jpeg",
+		},
+	}
+
+	model := apiFilm.mapToModel(serviceConfig, itemIndex)
+
+	assert.Equal(t, "film-portrait.jpeg", model.Bonuses[0].Images.Portrait)
+	assert.Equal(t, "film-landscape.jpeg", model.Bonuses[0].Images.Landscape)
+	assert.Equal(t, "film-header.jpeg", model.Bonuses[0].Images.Header)
+	assert.Equal(t, "film-carousel.jpeg", model.Bonuses[0].Images.Carousel)
+	assert.Equal(t, "film-background.jpeg", model.Bonuses[0].Images.Background)
+	assert.Equal(t, "film-classification.jpeg", model.Bonuses[0].Images.Classification)
+}
+
+func TestBonusContentImagesUseSeasonImagesAsFallback(t *testing.T) {
+
+	itemIndex := make(models.ItemIndex)
+
+	serviceConfig := commonServiceConfig()
+
+	apiSeason := tvSeasonV2{
+		Slug:     "/tv/12/season/4",
+		Title:    "Season Fourth",
+		Overview: "Season overview",
+		ShowInfo: tvShowV2{
+			Title: "Show Twelth",
+		},
+		Bonuses: []bonusContentV2{{
+			Number: 1,
+			Title:  "Behind the scenes",
+		}},
+		ImageUrls: struct {
+			Portrait       string `json:"portrait"`
+			Landscape      string `json:"landscape"`
+			Header         string `json:"header"`
+			Carousel       string `json:"carousel"`
+			Bg             string `json:"bg"`
+			Classification string `json:"classification"`
+		}{
+			Portrait:       "season-portrait.jpeg",
+			Landscape:      "season-landscape.jpeg",
+			Header:         "season-header.jpeg",
+			Carousel:       "season-carousel.jpeg",
+			Bg:             "season-background.jpeg",
+			Classification: "season-classification.jpeg",
+		},
+	}
+
+	model := apiSeason.mapToModel(serviceConfig, itemIndex)
+
+	assert.Equal(t, "season-portrait.jpeg", model.Bonuses[0].Images.Portrait)
+	assert.Equal(t, "season-landscape.jpeg", model.Bonuses[0].Images.Landscape)
+	assert.Equal(t, "season-header.jpeg", model.Bonuses[0].Images.Header)
+	assert.Equal(t, "season-carousel.jpeg", model.Bonuses[0].Images.Carousel)
+	assert.Equal(t, "season-background.jpeg", model.Bonuses[0].Images.Background)
+	assert.Equal(t, "season-classification.jpeg", model.Bonuses[0].Images.Classification)
+}

--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -186,43 +186,12 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 
 	// add bonuses - supports linking to bonus entries (supported??)
 	for _, bonus := range f.Bonuses {
-		b := bonus.mapToModel2(film, serviceConfig, itemIndex)
+		b := bonus.mapToModel2(film.Slug, film.Images)
 		film.Bonuses = append(film.Bonuses, b)
 		itemIndex.Set(b.Slug, b.GetGenericItem())
 	}
 
 	return film
-}
-
-func (fb filmBonusV2) mapToModel2(film models.Film, serviceConfig models.ServiceConfig, itemIndex models.ItemIndex) models.FilmBonus {
-
-	b := models.FilmBonus{
-		Slug:     fmt.Sprintf("%s/bonus/%d", film.Slug, fb.Number),
-		Number:   fb.Number,
-		Title:    fb.Title,
-		Runtime:  models.Runtime(fb.Runtime),
-		Overview: fb.Overview,
-		Images: models.ImageSet{
-			Portrait:       utils.Coalesce(fb.ImageUrls.Portrait, film.Images.Portrait),
-			Landscape:      utils.Coalesce(fb.ImageUrls.Landscape, film.Images.Landscape),
-			Header:         utils.Coalesce(fb.ImageUrls.Header, film.Images.Header),
-			Carousel:       utils.Coalesce(fb.ImageUrls.Carousel, film.Images.Carousel),
-			Background:     utils.Coalesce(fb.ImageUrls.Bg, film.Images.Background),
-			Classification: utils.Coalesce(fb.ImageUrls.Classification, film.Images.Classification),
-		},
-	}
-
-	for _, t := range fb.Subtitles {
-		b.Subtitles = append(b.Subtitles, models.SubtitleTrack{
-			Language: t.Language,
-			Name:     t.Name,
-			Type:     t.Type,
-			Path:     t.Path,
-		})
-	}
-
-	return b
-
 }
 
 // Film - all of the film bits
@@ -231,7 +200,7 @@ type filmV2 struct {
 		URL  string `json:"url"`
 		Type string `json:"type"`
 	} `json:"trailers,omitempty"`
-	Bonuses []filmBonusV2 `json:"bonuses"`
+	Bonuses []bonusContentV2 `json:"bonuses"`
 	Cast    []struct {
 		Name      string `json:"name"`
 		Character string `json:"character"`
@@ -267,23 +236,6 @@ type filmV2 struct {
 	SeoTitle        string            `json:"seo_title"`
 	SeoKeywords     string            `json:"seo_keywords"`
 	SeoDescription  string            `json:"seo_description"`
-}
-
-// FilmBonus - film bonus model
-type filmBonusV2 struct {
-	Number    int     `json:"number"`
-	Title     string  `json:"title"`
-	Overview  string  `json:"description"`
-	Runtime   float64 `json:"runtime"`
-	ImageUrls struct {
-		Portrait       string `json:"portrait"`
-		Landscape      string `json:"landscape"`
-		Header         string `json:"header"`
-		Carousel       string `json:"carousel"`
-		Bg             string `json:"bg"`
-		Classification string `json:"classification"`
-	} `json:"image_urls"`
-	Subtitles []subtitleTrackV1 `json:"subtitle_tracks"`
 }
 
 type subtitleTrackV1 struct {

--- a/kibble/api/films_test.go
+++ b/kibble/api/films_test.go
@@ -81,7 +81,7 @@ func TestFilmApiToModel(t *testing.T) {
 			Path:     "/subtitles/film/49/bonus/1/it/caption-18.vtt",
 		}},
 		Recommendations: []string{"/film/1", "/film/2"},
-		Bonuses: []filmBonusV2{{
+		Bonuses: []bonusContentV2{{
 			Number: 1,
 			Title:  "Behind the scenes",
 			ImageUrls: struct {
@@ -125,47 +125,4 @@ func TestFilmApiToModel(t *testing.T) {
 	assert.Equal(t, 2, len(itemIndex["film"]), "expect the item index to include 2 films")
 
 	assert.Equal(t, 1, len(model.Subtitles), "expect the subtitles to be 1")
-}
-
-func TestBonusContentImagesUseFilmImagesAsFallback(t *testing.T) {
-
-	itemIndex := make(models.ItemIndex)
-
-	serviceConfig := commonServiceConfig()
-
-	apiFilm := filmV2{
-		ID:      123,
-		Title:   "Film One",
-		Slug:    "/film/52",
-		Tagline: "Tag line",
-		Runtime: 123,
-		Bonuses: []filmBonusV2{{
-			Number: 1,
-			Title:  "Behind the scenes",
-		}},
-		ImageUrls: struct {
-			Portrait       string `json:"portrait"`
-			Landscape      string `json:"landscape"`
-			Header         string `json:"header"`
-			Carousel       string `json:"carousel"`
-			Bg             string `json:"bg"`
-			Classification string `json:"classification"`
-		}{
-			Portrait:       "film-portrait.jpeg",
-			Landscape:      "film-landscape.jpeg",
-			Header:         "film-header.jpeg",
-			Carousel:       "film-carousel.jpeg",
-			Bg:             "film-background.jpeg",
-			Classification: "film-classification.jpeg",
-		},
-	}
-
-	model := apiFilm.mapToModel(serviceConfig, itemIndex)
-
-	assert.Equal(t, "film-portrait.jpeg", model.Bonuses[0].Images.Portrait)
-	assert.Equal(t, "film-landscape.jpeg", model.Bonuses[0].Images.Landscape)
-	assert.Equal(t, "film-header.jpeg", model.Bonuses[0].Images.Header)
-	assert.Equal(t, "film-carousel.jpeg", model.Bonuses[0].Images.Carousel)
-	assert.Equal(t, "film-background.jpeg", model.Bonuses[0].Images.Background)
-	assert.Equal(t, "film-classification.jpeg", model.Bonuses[0].Images.Classification)
 }

--- a/kibble/api/tv.go
+++ b/kibble/api/tv.go
@@ -220,6 +220,13 @@ func (t tvSeasonV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex mod
 		season.Episodes = append(season.Episodes, t.mapToModel(season))
 	}
 
+	// add bonuses - supports linking to bonus entries (supported??)
+	for _, bonus := range t.Bonuses {
+		b := bonus.mapToModel2(season.Slug, season.Images)
+		season.Bonuses = append(season.Bonuses, b)
+		itemIndex.Set(b.Slug, b.GetGenericItem())
+	}
+
 	return season
 }
 
@@ -320,7 +327,8 @@ type tvSeasonV2 struct {
 		URL  string `json:"url"`
 		Type string `json:"type"`
 	} `json:"trailers"`
-	Episodes []tvEpisodeV2 `json:"episodes"`
+	Episodes []tvEpisodeV2    `json:"episodes"`
+	Bonuses  []bonusContentV2 `json:"bonuses"`
 	Cast     []struct {
 		Name      string `json:"name"`
 		Character string `json:"character"`

--- a/kibble/api/tv_test.go
+++ b/kibble/api/tv_test.go
@@ -165,3 +165,42 @@ func TestEpisodeImageFallback(t *testing.T) {
 	assert.Equal(t, "season-background.jpeg", model.Episodes[0].Images.Background)
 	assert.Equal(t, "season-classification.jpeg", model.Episodes[0].Images.Classification)
 }
+
+func TestBonusContentModelBinding(t *testing.T) {
+	itemIndex := make(models.ItemIndex)
+
+	serviceConfig := commonServiceConfig()
+
+	apiSeason := tvSeasonV2{
+		Slug:     "/tv/12/season/4",
+		Title:    "Season Fourth",
+		Overview: "Season overview",
+		ShowInfo: tvShowV2{
+			Title: "Show Twelth",
+		},
+		Bonuses: []bonusContentV2{{
+			Number: 1,
+			Title:  "Behind the scenes",
+			ImageUrls: struct {
+				Portrait       string `json:"portrait"`
+				Landscape      string `json:"landscape"`
+				Header         string `json:"header"`
+				Carousel       string `json:"carousel"`
+				Bg             string `json:"bg"`
+				Classification string `json:"classification"`
+			}{
+				Portrait:       "portrait",
+				Landscape:      "landscape",
+				Classification: "classification",
+			},
+		}},
+	}
+
+	model := apiSeason.mapToModel(serviceConfig, itemIndex)
+
+	assert.Equal(t, 1, len(model.Bonuses), "expect 1 bonus")
+	assert.Equal(t, "/tv/12/season/4/bonus/1", model.Bonuses[0].Slug, "bonus.slug")
+
+	assert.Equal(t, "portrait", model.Bonuses[0].Images.Portrait)
+	assert.Equal(t, "landscape", model.Bonuses[0].Images.Landscape)
+}

--- a/kibble/models/bonus_content.go
+++ b/kibble/models/bonus_content.go
@@ -1,0 +1,26 @@
+package models
+
+// BonusContentCollection - all bonus content for a film or season
+type BonusContentCollection []BonusContent
+
+// BonusContent - bonus content model
+type BonusContent struct {
+	Slug      string
+	Number    int
+	Title     string
+	Images    ImageSet
+	Subtitles []SubtitleTrack
+	Runtime   Runtime
+	Overview  string
+}
+
+// GetGenericItem - returns a generic item based on the film bonus
+func (bonus BonusContent) GetGenericItem() GenericItem {
+	return GenericItem{
+		Title:     bonus.Title,
+		Slug:      bonus.Slug,
+		Images:    bonus.Images,
+		ItemType:  "bonus",
+		InnerItem: bonus,
+	}
+}

--- a/kibble/models/film.go
+++ b/kibble/models/film.go
@@ -23,7 +23,7 @@ type Film struct {
 	Title           string
 	TitleSlug       string
 	Trailers        []Trailer
-	Bonuses         FilmBonusCollection
+	Bonuses         BonusContentCollection
 	Cast            []CastMember
 	Crew            []CrewMember
 	Studio          []string
@@ -38,20 +38,6 @@ type Film struct {
 	Images          ImageSet
 	Recommendations []GenericItem
 	Subtitles       []SubtitleTrack
-}
-
-// FilmBonusCollection - all films
-type FilmBonusCollection []FilmBonus
-
-// FilmBonus - film bonus model
-type FilmBonus struct {
-	Slug      string
-	Number    int
-	Title     string
-	Images    ImageSet
-	Subtitles []SubtitleTrack
-	Runtime   Runtime
-	Overview  string
 }
 
 // FilmCollection - all films
@@ -85,16 +71,5 @@ func (film Film) GetGenericItem() GenericItem {
 		Images:    film.Images,
 		ItemType:  "film",
 		InnerItem: film,
-	}
-}
-
-// GetGenericItem - returns a generic item based on the film bonus
-func (bonus FilmBonus) GetGenericItem() GenericItem {
-	return GenericItem{
-		Title:     bonus.Title,
-		Slug:      bonus.Slug,
-		Images:    bonus.Images,
-		ItemType:  "bonus",
-		InnerItem: bonus,
 	}
 }

--- a/kibble/models/tv.go
+++ b/kibble/models/tv.go
@@ -65,6 +65,7 @@ type TVSeason struct {
 	Images          ImageSet
 	Trailers        []Trailer
 	Episodes        []TVEpisode
+	Bonuses         BonusContentCollection
 	Cast            []CastMember
 	Crew            []CrewMember
 	Recommendations []GenericItem


### PR DESCRIPTION
Add bonus content to seasons 

Refactors:
- Split out bonus content (api and models) into separate files.
- Removed 'film' suffix from bonus content models to indicate its a valid type on things (seasons) other than films.
- Moved some bonus content tests around if they were specific to bonus content.