### PR TITLE
Bundles are missing taglines and descriptions

### DIFF
--- a/kibble/api/bundles.go
+++ b/kibble/api/bundles.go
@@ -70,9 +70,11 @@ func (b BundleV1) mapToModel(serviceConfig models.ServiceConfig, itemIndex model
 			Image:       serviceConfig.SelectDefaultImageType(b.LandscapeImage, b.PortraitImage),
 			VideoURL:    b.PromoURL,
 		},
-		Items:     itemIndex.MapToUnresolvedItems(b.Items),
-		CreatedAt: b.CreatedAt,
-		UpdatedAt: b.UpdatedAt,
+		Items:       itemIndex.MapToUnresolvedItems(b.Items),
+		CreatedAt:   b.CreatedAt,
+		UpdatedAt:   b.UpdatedAt,
+		Description: b.Description,
+		Tagline:     b.Tagline,
 	}
 }
 

--- a/kibble/api/bundles_test.go
+++ b/kibble/api/bundles_test.go
@@ -92,6 +92,7 @@ func TestBundlesApiToModel(t *testing.T) {
 		LandscapeImage: "landscape",
 		PromoURL:       "https://video",
 		Items:          []string{"/film/1", "/film/2"},
+		Tagline:        "this is my tagline",
 	}
 
 	model := apiBundle.mapToModel(serviceConfig, itemIndex)
@@ -105,4 +106,7 @@ func TestBundlesApiToModel(t *testing.T) {
 	assert.Equal(t, nil, model.Items[0].InnerItem, "expect inner item to be nil")
 
 	assert.Equal(t, 2, len(itemIndex["film"]), "expect the item index to include 2 films")
+
+	assert.Equal(t, "this is my tagline", model.Tagline, "expect tagline")
+	assert.Equal(t, "Bundle description", model.Description, "expect description")
 }


### PR DESCRIPTION
I'm new to Go but by the looks of things Taglines and Descriptions aren't being populated in the Bundle objects like they are in other models (e.g. Films & Collections). I've added support for pulling down Taglines and Descriptions for Bundles.