### PR TITLE
Make silent test failures noisy

### DIFF
--- a/kibble/test/inmemory_renderer.go
+++ b/kibble/test/inmemory_renderer.go
@@ -89,21 +89,18 @@ func (c *InMemoryRenderer) Render(templatePath string, filePath string, data jet
 		filePath: filePath,
 	}
 
-	c.Results = append(c.Results, result)
-
 	t, err := c.View.GetTemplate(templatePath)
+
 	if err != nil {
 		errCount++
 		result.err = err
-		fmt.Printf("error e: %s", err)
-		return
-	}
-
-	if err = t.Execute(result.buffer, data, nil); err != nil {
+		fmt.Printf("GetTemplate() error: %s\n", err)
+	} else if err = t.Execute(result.buffer, data, nil); err != nil {
 		errCount++
-		fmt.Printf("error t: %s", err)
 		result.err = err
+		fmt.Printf("Execute() error: %s\n", err)
 	}
 
+	c.Results = append(c.Results, result)
 	return
 }


### PR DESCRIPTION
There were two tests outputting errors that were only visible if you ran with verbose output and they didn't cause the tests to fail. They now fail by appending the result after the error is assigned. Next step will be to fix them.

# Before
## `make test`

```
/shift72-kibble/kibble$ make test
go test -cover ./...
?       kibble  [no test files]
ok      kibble/api      (cached)        coverage: 34.3% of statements
?       kibble/cmd      [no test files]
ok      kibble/config   (cached)        coverage: 13.8% of statements
ok      kibble/datastore        (cached)        coverage: 61.2% of statements
?       kibble/initalise        [no test files]
ok      kibble/models   (cached)        coverage: 44.9% of statements
?       kibble/publish  [no test files]
ok      kibble/render   (cached)        coverage: 3.6% of statements
ok      kibble/sync     (cached)        coverage: 34.5% of statements
?       kibble/test     [no test files]
ok      kibble/utils    (cached)        coverage: 28.8% of statements
?       kibble/version  [no test files]
```

## Verbose

```
/shift72-kibble/kibble/datastore$ go test -v -run '^Test(?:Film|Taxonomy)DataStore$'
=== RUN   TestFilmDataStore
error e: template film/item.jet can't be loaded--- PASS: TestFilmDataStore (0.00s)
=== RUN   TestTaxonomyDataStore
error e: template film/item.jet can't be loaded--- PASS: TestTaxonomyDataStore (0.00s)
PASS
ok      kibble/datastore        0.013s
```

# After
## `make test`

```
/shift72-kibble/kibble$ make test
go test -cover ./...
?       kibble  [no test files]
ok      kibble/api      (cached)        coverage: 34.3% of statements
?       kibble/cmd      [no test files]
ok      kibble/config   (cached)        coverage: 13.8% of statements
GetTemplate() error: template film/item.jet can't be loaded
--- FAIL: TestFilmDataStore (0.00s)
    films_test.go:90: Unexpected errors
GetTemplate() error: template film/item.jet can't be loaded
--- FAIL: TestTaxonomyDataStore (0.00s)
    taxonomy_test.go:56: Unexpected errors
FAIL
coverage: 61.2% of statements
FAIL    kibble/datastore        0.034s
?       kibble/initalise        [no test files]
ok      kibble/models   (cached)        coverage: 44.9% of statements
?       kibble/publish  [no test files]
ok      kibble/render   (cached)        coverage: 3.6% of statements
ok      kibble/sync     (cached)        coverage: 34.5% of statements
?       kibble/test     [no test files]
ok      kibble/utils    (cached)        coverage: 28.8% of statements
?       kibble/version  [no test files]
FAIL
make: *** [Makefile:30: test] Error 1
```

## Verbose

```
/shift72-kibble/kibble/datastore$ go test -v -run '^Test(?:Film|Taxonomy)DataStore$'
=== RUN   TestFilmDataStore
GetTemplate() error: template film/item.jet can't be loaded
    films_test.go:90: Unexpected errors
--- FAIL: TestFilmDataStore (0.00s)
=== RUN   TestTaxonomyDataStore
GetTemplate() error: template film/item.jet can't be loaded
    taxonomy_test.go:56: Unexpected errors
--- FAIL: TestTaxonomyDataStore (0.00s)
FAIL
exit status 1
FAIL    kibble/datastore        0.013s
```