### PR TITLE
ignore tls verification for the reverse proxy and loading from the api

### DIFF
--- a/kibble/render/reverse_proxy.go
+++ b/kibble/render/reverse_proxy.go
@@ -15,6 +15,7 @@
 package render
 
 import (
+	"crypto/tls"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -46,8 +47,14 @@ func NewProxy(target string, patterns []string) *Prox {
 	}
 
 	return &Prox{
-		target:   url,
-		proxy:    &httputil.ReverseProxy{Director: director},
+		target: url,
+		proxy: &httputil.ReverseProxy{Director: director,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		},
 		patterns: res,
 	}
 }


### PR DESCRIPTION
When developing locally using self sign certificates it is unnecessary to verify the TLS certificates.
Scenarios:
a) loading data from the API (kibble local development and kibble render)
b) reverse proxying any requests (kibble local development)
