### PR TITLE
Separate release from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # kibble
 
-def: To chop or grind coarsely
+> def: To chop or grind coarsely
 
 [Changelog](changelog.md)
 
@@ -30,64 +30,6 @@ def: To chop or grind coarsely
 * Requires go 1.14.0 (go mod)
 * Build and install ```go install```
 * Check installed and running correctly ```kibble version```
-
-## Publish
-
-Publish will zip all files placed in the ```/.kibble/dist``` directory
-
-```bash
-
-/.kibble
-  /dist       - publish directory
-  /kibble.zip - zip file to be published
-
-```
-
-## Releasing new versions
-
-Kibble is released to 3 places
-
-  1. github - mostly historical purposes
-  2. SHIFT72 Platform - this is where the platform will pull the kibble release from
-  3. NPM - to support installation for third parties via npm and the node js environment
-
-## a. Update version numbers and change log
-
-```
-changelog.mpd
-kibble-npm/package.json
-```
-
-## b. Commit changes
-
-```
-git commit -a -m "release nnn"
-```
-
-## c. Tag Commit
-  Ensure that the release is tagged correctly. Miss the prepended 'v' as this will mess S3 up.
-
-```
-git tag 0.9.6 master
-git push origin 0.9.6
-```
-
-## d. build and release to locations 1 and 2
-
-```
-make release
-```
-
-## e. register new build in uber admin
-
-Manual step, create rows for the staging and production versions
-  * http://localhost:10001/admin/user~builder_version
-  * http://localhost:10002/admin/user~builder_version
-
-
-## f. update any sample templates with the new kibble version
-
-
 
 # Supports
 

--- a/release.md
+++ b/release.md
@@ -1,0 +1,57 @@
+# Release
+
+## Publish
+
+Publish will zip all files placed in the ```/.kibble/dist``` directory
+
+```bash
+
+/.kibble
+  /dist       - publish directory
+  /kibble.zip - zip file to be published
+
+```
+
+## Releasing new versions - Shift72 internal only
+
+Kibble is released to 3 places
+
+  1. GitHub
+  2. SHIFT72 Platform - this is where the platform will pull the kibble release from
+  3. NPM - to support installation for third parties via NPM and Node.js environment
+
+### a. Update version numbers and change log
+
+```
+changelog.mpd
+kibble-npm/package.json
+```
+
+### b. Commit changes
+
+```
+git commit -a -m "release nnn"
+```
+
+### c. Tag Commit
+  Ensure that the release is tagged correctly. Miss the prepended 'v' as this will mess S3 up.
+
+```
+git tag 0.9.6 master
+git push origin 0.9.6
+```
+
+### d. build and release to locations 1 and 2
+
+```
+make release
+```
+
+### e. register new build in uber admin
+
+Manual step, create rows for the staging and production versions
+  * http://localhost:10001/admin/user~builder_version
+  * http://localhost:10002/admin/user~builder_version
+
+
+### f. update any sample templates with the new kibble version

--- a/release.md
+++ b/release.md
@@ -23,7 +23,7 @@ Kibble is released to 3 places
 ### a. Update version numbers and change log
 
 ```
-changelog.mpd
+changelog.md
 kibble-npm/package.json
 ```
 


### PR DESCRIPTION
Thoughts on moving this out of the main README? It's got some internal things - I've added "Shift72 internal only" to the releasing header. Even though uber isn't public, mentioning it publically still gives me the tingels. Perhaps it should be hidden from public view altogether? Yes, I know it's in the git history now...