### PR TITLE
use siteRootPath when determining the FileSystem templatePath

### DIFF
--- a/kibble/.vscode/settings.json
+++ b/kibble/.vscode/settings.json
@@ -1,12 +1,15 @@
 {
     "cSpell.words": [
+        "Debugf",
         "Infof",
         "Initialise",
         "Stopwatchf",
         "Tfunc",
         "Warningf",
+        "hashicorp",
         "iframe",
         "isset",
+        "lebowski",
         "localised",
         "noopener",
         "stretchr",

--- a/kibble/Makefile
+++ b/kibble/Makefile
@@ -33,7 +33,7 @@ run-darwin: darwin
 	cd sample_site && ../kibble render
 
 run-linux: linux
-	cd sample_site && ../kibble render
+	cd sample_site && ../kibble render -v
 
 clean:
 	$(GOCLEAN)

--- a/kibble/datastore/films_test.go
+++ b/kibble/datastore/films_test.go
@@ -86,7 +86,8 @@ func TestFilmDataStore(t *testing.T) {
 		Routes: []models.Route{*ctx.Route},
 	}
 
-	routeRegistry := models.NewRouteRegistryFromConfig(&cfg)
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
 
 	i18n.MustLoadTranslationFile("../sample_site/en_US.all.json")
 	T, _ := i18n.Tfunc("en-US")
@@ -172,7 +173,8 @@ func TestRenderingSlug(t *testing.T) {
 		},
 	}
 
-	routeRegistry := models.NewRouteRegistryFromConfig(&cfg)
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
 
 	view := models.CreateTemplateView(routeRegistry, i18n.IdentityTfunc(), &ctx, "./templates")
 
@@ -220,7 +222,8 @@ func TestRouteToFilm(t *testing.T) {
 		Routes: []models.Route{*r},
 	}
 
-	routeRegistry := models.NewRouteRegistryFromConfig(&cfg)
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
 
 	view := models.CreateTemplateView(routeRegistry, i18n.IdentityTfunc(), &ctx, "./templates")
 
@@ -267,7 +270,8 @@ func TestTransLanguage(t *testing.T) {
 		Routes: []models.Route{*r},
 	}
 
-	routeRegistry := models.NewRouteRegistryFromConfig(&cfg)
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
 
 	view := models.CreateTemplateView(routeRegistry, i18n.IdentityTfunc(), &ctx, "./templates")
 

--- a/kibble/datastore/route_registry_test.go
+++ b/kibble/datastore/route_registry_test.go
@@ -1,0 +1,153 @@
+package datastore
+
+import (
+	"kibble/models"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadFilmDataSourceRoutesFromConfig(t *testing.T) {
+
+	models.AddDataSource(&FilmDataSource{})
+
+	cfg := models.Config{
+		Routes: []models.Route{
+			{
+				Name:         "filmItem",
+				URLPath:      "/film-special/:filmID",
+				TemplatePath: "film/item.jet",
+				DataSource:   "Film",
+			},
+		},
+	}
+
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
+
+	routes := routeRegistry.GetAll()
+
+	assert.Equal(t, routes[0].TemplatePath, "film/item.jet")
+}
+
+func TestLoadDefaultFileSystemRouteFromConfig(t *testing.T) {
+
+	models.AddDataSource(&FileSystemDataSource{})
+
+	cfg := models.Config{
+		Routes: []models.Route{},
+	}
+
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
+
+	routes := routeRegistry.GetAll()
+
+	assert.Equal(t, routes[0].TemplatePath, ".")
+}
+
+func TestLoadDefaultFileSystemRouteFromConfigWithSiteRootPath(t *testing.T) {
+
+	models.AddDataSource(&FileSystemDataSource{})
+
+	cfg := models.Config{
+		SiteRootPath: "site",
+		Routes:       []models.Route{},
+	}
+
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
+
+	routes := routeRegistry.GetAll()
+
+	assert.Equal(t, routes[0].TemplatePath, "site")
+}
+
+func TestLoadCustomFileSystemRouteFromConfigWithSiteRootPath(t *testing.T) {
+
+	models.AddDataSource(&FileSystemDataSource{})
+
+	cfg := models.Config{
+		SiteRootPath: "site",
+		Routes: []models.Route{
+			{
+				Name:         "well-known",
+				URLPath:      "",
+				TemplatePath: ".well-known",
+				DataSource:   "FileSystem",
+			},
+		},
+	}
+
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
+
+	routes := routeRegistry.GetAll()
+
+	assert.Equal(t, routes[0].TemplatePath, "site/.well-known")
+}
+
+func TestLoadCustomFileSystemRouteFromConfigWithCurrentSiteRootPath(t *testing.T) {
+
+	models.AddDataSource(&FileSystemDataSource{})
+
+	cfg := models.Config{
+		SiteRootPath: ".",
+		Routes: []models.Route{
+			{
+				Name:         "well-known",
+				URLPath:      "",
+				TemplatePath: ".well-known",
+				DataSource:   "FileSystem",
+			},
+		},
+	}
+
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
+
+	routes := routeRegistry.GetAll()
+
+	assert.Equal(t, routes[0].TemplatePath, ".well-known")
+}
+
+func TestLoadCustomFileSystemRouteWithSiteRootPathInvalidPathTraveral(t *testing.T) {
+
+	models.AddDataSource(&FileSystemDataSource{})
+
+	cfg := models.Config{
+		SiteRootPath: "../../../site",
+		Routes: []models.Route{
+			{
+				Name:         "well-known",
+				URLPath:      "",
+				TemplatePath: ".well-known",
+				DataSource:   "FileSystem",
+			},
+		},
+	}
+
+	_, err := models.NewRouteRegistryFromConfig(&cfg)
+
+	assert.Error(t, err)
+}
+
+func TestLoadCustomFileSystemRouteWithSiteRootPathInvalidRootPathTraveral(t *testing.T) {
+
+	models.AddDataSource(&FileSystemDataSource{})
+
+	cfg := models.Config{
+		SiteRootPath: "/",
+		Routes: []models.Route{
+			{
+				Name:         "well-known",
+				URLPath:      "",
+				TemplatePath: ".well-known",
+				DataSource:   "FileSystem",
+			},
+		},
+	}
+
+	_, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.Error(t, err)
+}

--- a/kibble/datastore/taxonomy_test.go
+++ b/kibble/datastore/taxonomy_test.go
@@ -21,6 +21,7 @@ import (
 	"kibble/test"
 
 	"github.com/nicksnyder/go-i18n/i18n"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTaxonomyDataStore(t *testing.T) {
@@ -51,7 +52,8 @@ func TestTaxonomyDataStore(t *testing.T) {
 		Routes: []models.Route{*ctx.Route},
 	}
 
-	routeRegistry := models.NewRouteRegistryFromConfig(&cfg)
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
 
 	i18n.MustLoadTranslationFile("../sample_site/en_US.all.json")
 	T, _ := i18n.Tfunc("en-US")

--- a/kibble/datastore/tv_show_test.go
+++ b/kibble/datastore/tv_show_test.go
@@ -21,6 +21,7 @@ import (
 	"kibble/test"
 
 	"github.com/nicksnyder/go-i18n/i18n"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRenderingShowSlug(t *testing.T) {
@@ -52,7 +53,8 @@ func TestRenderingShowSlug(t *testing.T) {
 		},
 	}
 
-	routeRegistry := models.NewRouteRegistryFromConfig(&cfg)
+	routeRegistry, err := models.NewRouteRegistryFromConfig(&cfg)
+	assert.NoError(t, err)
 
 	view := models.CreateTemplateView(routeRegistry, i18n.IdentityTfunc(), &ctx, "./templates")
 

--- a/kibble/render/render.go
+++ b/kibble/render/render.go
@@ -82,7 +82,11 @@ func Render(sourcePath string, buildPath string, cfg *models.Config) int {
 		return 1
 	}
 
-	routeRegistry := models.NewRouteRegistryFromConfig(cfg)
+	routeRegistry, err := models.NewRouteRegistryFromConfig(cfg)
+	if err != nil {
+		log.Errorf("Loading site config failed: %s", err)
+		return 1
+	}
 
 	renderer := FileRenderer{
 		buildPath:  buildPath,


### PR DESCRIPTION
The `SiteRootPath` was not being used when determining the files to load and render as part of the `FileSystemDataSource`.

Added some checks to prevent for malicious pathing.