### PR TITLE
AB#4717 Trim whitespace from certain metadata fields

### DIFF
--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -155,7 +155,7 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 	}
 
 	for _, s := range f.Studio {
-		film.Studio = append(film.Studio, s.Name)
+		film.Studio = append(film.Studio, strings.TrimSpace(s.Name))
 	}
 
 	for key, value := range f.Classifications {
@@ -191,16 +191,16 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 	// cast
 	for _, t := range f.Cast {
 		film.Cast = append(film.Cast, models.CastMember{
-			Name:      t.Name,
-			Character: t.Character,
+			Name:      strings.TrimSpace(t.Name),
+			Character: strings.TrimSpace(t.Character),
 		})
 	}
 
 	// crew
 	for _, t := range f.Crew {
 		film.Crew = append(film.Crew, models.CrewMember{
-			Name: t.Name,
-			Job:  t.Job,
+			Name: strings.TrimSpace(t.Name),
+			Job:  strings.TrimSpace(t.Job),
 		})
 	}
 

--- a/kibble/api/films_test.go
+++ b/kibble/api/films_test.go
@@ -62,6 +62,9 @@ func getFilm() filmV2 {
 		}{{
 			Name:      "James Earl Jones",
 			Character: "Darth Vadar",
+		}, {
+			Name: "	Tab Hunter	",
+			Character: "  Gwen Spacy",
 		}},
 		Crew: []struct {
 			Name string `json:"name"`
@@ -103,9 +106,9 @@ func getFilm() filmV2 {
 		Studio: []struct {
 			Name string `json:"name"`
 		}{{
-			Name: "Studio ABC",
+			Name: "	Studio ABC	",
 		}, {
-			Name: "Studio XYZ",
+			Name: "  Studio XYZ  ",
 		}},
 		Classifications: map[string]classificationV1{
 			"au": {
@@ -144,6 +147,8 @@ func TestFilmApiToModel(t *testing.T) {
 	assert.Equal(t, "https://cdn/trailer.mp4", model.Seo.VideoURL, "seo.videourl")
 
 	assert.Equal(t, "Darth Vadar", model.Cast[0].Character, "cast.character")
+	assert.Equal(t, "Tab Hunter", model.Cast[1].Name, "cast.character")
+	assert.Equal(t, "Gwen Spacy", model.Cast[1].Character, "cast.character")
 	assert.Equal(t, "Peter Jackson", model.Crew[0].Name, "crew.name")
 
 	assert.Equal(t, 1, len(model.Bonuses), "expect 1 bonus")


### PR DESCRIPTION
- Structured data from Curzon has helped illustrate how loose some of the data expected in metadata field is for JSON purposes
- Names and studios don't need spaces / tabs at either end
- Probably could do other fields; left as an exercise to the reader
- Tests