### PR TITLE
Ab#4407 slider component does not strip html tags from short description field

### DIFF
--- a/kibble/go.mod
+++ b/kibble/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/btree v0.0.0-20161217183710-316fb6d3f031 // indirect
 	github.com/gosimple/slug v1.1.1
 	github.com/gregjones/httpcache v0.0.0-20170926212834-c1f8028e62ad
+	github.com/grokify/html-strip-tags-go v0.0.1
 	github.com/hashicorp/go-version v0.0.0-20170914154128-fc61389e27c7
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 // indirect

--- a/kibble/models/template.go
+++ b/kibble/models/template.go
@@ -25,6 +25,7 @@ import (
 	"kibble/version"
 
 	"github.com/CloudyKit/jet"
+	strip "github.com/grokify/html-strip-tags-go"
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/nicksnyder/go-i18n/i18n"
 	"gopkg.in/russross/blackfriday.v2"
@@ -192,6 +193,10 @@ func CreateTemplateView(routeRegistry *RouteRegistry, trans i18n.TranslateFunc, 
 	view.AddGlobal("append", func(slice []string, newValue string) []string {
 		s := append(slice, newValue)
 		return s
+	})
+
+	view.AddGlobal("stripHTML", func(key string) string {
+		return strip.StripTags(key)
 	})
 
 	return view

--- a/kibble/models/template_test.go
+++ b/kibble/models/template_test.go
@@ -15,6 +15,7 @@
 package models
 
 import (
+	"fmt"
 	"testing"
 
 	"kibble/test"
@@ -420,4 +421,17 @@ func TestI18nPathPrefixFormattingWithNonDefaultLanguageAndPathHasNoSlash(t *test
 	renderer1.DumpResults()
 
 	assert.Contains(t, renderer1.Results[0].Output(), "href=\"/fr/no-slash.html\"")
+}
+
+func TestViewStringMethods(t *testing.T) {
+
+	site := &Site{
+		Config: ServiceConfig{
+			"device_user_limit": "3",
+		},
+	}
+
+	renderer := setupViewRenderer(site, nil)
+
+	fmt.Printf("%+v\n", renderer.View.stripHTML)
 }

--- a/kibble/models/template_test.go
+++ b/kibble/models/template_test.go
@@ -15,7 +15,6 @@
 package models
 
 import (
-	"fmt"
 	"testing"
 
 	"kibble/test"
@@ -298,7 +297,7 @@ func TestAvailabilityFormattingAndCustomFields(t *testing.T) {
 
 	assert.Contains(t, renderer1.Results[0].Output(), "This is true")
 	assert.Contains(t, renderer1.Results[0].Output(), "some string here == 99")
-
+	assert.Contains(t, renderer1.Results[0].Output(), "tags should be stripped")
 }
 
 func TestI18nPathPrefixFormattingWithDefaultLanguage(t *testing.T) {
@@ -421,17 +420,4 @@ func TestI18nPathPrefixFormattingWithNonDefaultLanguageAndPathHasNoSlash(t *test
 	renderer1.DumpResults()
 
 	assert.Contains(t, renderer1.Results[0].Output(), "href=\"/fr/no-slash.html\"")
-}
-
-func TestViewStringMethods(t *testing.T) {
-
-	site := &Site{
-		Config: ServiceConfig{
-			"device_user_limit": "3",
-		},
-	}
-
-	renderer := setupViewRenderer(site, nil)
-
-	fmt.Printf("%+v\n", renderer.View.stripHTML)
 }

--- a/kibble/sample_site/templates/tv/detail.jet
+++ b/kibble/sample_site/templates/tv/detail.jet
@@ -33,3 +33,5 @@ Available To US West: [{{ tvseason.Available.To | zone: "America/Los_Angeles" | 
     This is true
     {{ tvseason.CustomFields["string"] }} == {{ tvseason.CustomFields["number"] }}
 {{ end }}
+
+{{ stripHTML("tags <br>should be stripped") }}


### PR DESCRIPTION
- Here's [the card](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Core%20team/Stories/?workitem=4407)
- adds a method that strips html tags to kibble
- test via template is sufficent as StripTags already tested by author (checked with Sarge about approach. Also I cant do any better until I learn golang)