### PR TITLE
Ab#4034 sitemap xml missing warning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 
 ## Unreleased
 Config for retrieving translations from a new Translations API - `useTranslationsAPI`. This API is not yet available but adding a feature toggle in advance for development.
+Fix expected sitemap extension validation.
 
 ## 0.15.17
 Support a wider range of date formats

--- a/kibble/publish/validator.go
+++ b/kibble/publish/validator.go
@@ -39,7 +39,7 @@ var expectedPaths = []descriptivePath{
 		purpose: "instruct robots on how to interact with the site",
 	},
 	descriptivePath{
-		path:    "sitemap.txt.jet",
+		path:    "sitemap.xml.jet",
 		purpose: "instruct search engines about the pages of interest",
 	},
 }


### PR DESCRIPTION
https://dev.azure.com/S72/SHIFT72/_workitems/edit/4034

Simple change!  Core template moved from sitemap.txt to sitemap.xml ages ago.