### PR TITLE
AB#5425 Assign plans to pages

### DIFF
--- a/kibble/api/plans.go
+++ b/kibble/api/plans.go
@@ -40,20 +40,11 @@ func LoadAllPlans(cfg *models.Config, site *models.Site, itemIndex models.ItemIn
 	}
 
 	for _, b := range apiPlans {
-		n := b.mapToModel(site.Config, itemIndex)
+		plan := b.mapToModel(site.Config, itemIndex)
 
-		for i := range site.Pages {
-			page := &site.Pages[i]
-			if page.ID == b.PageID {
-				// link to the page if it exists
-				n.Page = page
+		plan.LinkPlanToPage(site, b.PageID)
 
-				// Conversely, keep track of what plans a page is associated with
-				page.Plans = append(page.Plans, n)
-			}
-		}
-
-		site.Plans = append(site.Plans, n)
+		site.Plans = append(site.Plans, plan)
 	}
 
 	return nil

--- a/kibble/api/plans.go
+++ b/kibble/api/plans.go
@@ -19,8 +19,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gosimple/slug"
 	"kibble/models"
+
+	"github.com/gosimple/slug"
 )
 
 // LoadAllPlans - loads all active plans
@@ -41,9 +42,15 @@ func LoadAllPlans(cfg *models.Config, site *models.Site, itemIndex models.ItemIn
 	for _, b := range apiPlans {
 		n := b.mapToModel(site.Config, itemIndex)
 
-		// link to the page if it exists
-		if p, ok := site.Pages.FindPageByID(b.PageID); ok {
-			n.Page = p
+		for i := range site.Pages {
+			page := &site.Pages[i]
+			if page.ID == b.PageID {
+				// link to the page if it exists
+				n.Page = page
+
+				// Conversely, keep track of what plans a page is associated with
+				page.Plans = append(page.Plans, n)
+			}
 		}
 
 		site.Plans = append(site.Plans, n)

--- a/kibble/models/pages.go
+++ b/kibble/models/pages.go
@@ -41,6 +41,7 @@ type Page struct {
 	PageType        string
 	URL             string
 	CustomFields    CustomFields
+	Plans           []Plan
 }
 
 // Pages -

--- a/kibble/models/plans.go
+++ b/kibble/models/plans.go
@@ -34,3 +34,17 @@ type Plan struct {
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
+
+func (plan *Plan) LinkPlanToPage(site *Site, PageID int) {
+
+	for i := range site.Pages {
+		page := &site.Pages[i]
+		if page.ID == PageID {
+			// link to the page if it exists
+			plan.Page = page
+
+			// Conversely, keep track of what plans a page is associated with
+			page.Plans = append(page.Plans, *plan)
+		}
+	}
+}

--- a/kibble/models/plans_test.go
+++ b/kibble/models/plans_test.go
@@ -1,0 +1,34 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLinkPlanToPage(t *testing.T) {
+
+	site := Site{
+		Pages: Pages{
+			Page{
+				ID:        123,
+				Slug:      "/film/123",
+				TitleSlug: "the-big-lebowski",
+				Plans:     nil,
+			},
+		},
+	}
+
+	plan := Plan{
+		ID:   99,
+		Page: nil,
+	}
+
+	plan.LinkPlanToPage(&site, 123)
+
+	page := site.Pages[0]
+
+	assert.Equal(t, 1, len(page.Plans))
+	assert.Equal(t, plan, page.Plans[0])
+	assert.Equal(t, &page, plan.Page)
+}


### PR DESCRIPTION
- Link plans to pages (the reverse relationship already exists)
- A page can have multiple plans linked to it