### PR TITLE
AB#5526 Kibble support for new plans API fields

### DIFF
--- a/kibble/api/plans.go
+++ b/kibble/api/plans.go
@@ -59,6 +59,8 @@ func (p PlansV1) mapToModel(serviceConfig models.ServiceConfig, itemIndex models
 		Interval:        "",
 		IntervalCount:   0,
 		TrialPeriodDays: 0,
+		PlanType:        "",
+		ExpiryDate:      p.ExpiryDate,
 		PortraitImage:   serviceConfig.ForceAbsoluteImagePath(p.PortraitImage),
 		Description:     p.Description,
 		CreatedAt:       p.CreatedAt,
@@ -74,6 +76,9 @@ func (p PlansV1) mapToModel(serviceConfig models.ServiceConfig, itemIndex models
 	if p.TrialPeriodDays != nil {
 		m.TrialPeriodDays = *p.TrialPeriodDays
 	}
+	if p.PlanType != nil {
+		m.PlanType = *p.PlanType
+	}
 	return m
 }
 
@@ -85,9 +90,11 @@ type PlansV1 struct {
 	Status          string    `json:"status"`
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`
+	ExpiryDate      time.Time `json:"expiry_date"`
 	PageID          int       `json:"page_id"`
 	Interval        *string   `json:"interval"`
 	IntervalCount   *int      `json:"interval_count"`
+	PlanType        *string   `json:"plan_type"`
 	TrialPeriodDays *int      `json:"trial_period_days"`
 	PortraitImage   string    `json:"portrait_image"`
 }

--- a/kibble/models/plans.go
+++ b/kibble/models/plans.go
@@ -14,7 +14,9 @@
 
 package models
 
-import "time"
+import (
+	"time"
+)
 
 // PlanCollection is a list of published plans
 type PlanCollection []Plan
@@ -30,9 +32,11 @@ type Plan struct {
 	IntervalCount   int
 	TrialPeriodDays int
 	Page            *Page
+	PlanType        string
 	PortraitImage   string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
+	ExpiryDate      time.Time
 }
 
 func (plan *Plan) LinkPlanToPage(site *Site, PageID int) {
@@ -47,4 +51,8 @@ func (plan *Plan) LinkPlanToPage(site *Site, PageID int) {
 			page.Plans = append(page.Plans, *plan)
 		}
 	}
+}
+
+func (plan *Plan) HasExpiryDate() bool {
+	return !plan.ExpiryDate.IsZero()
 }


### PR DESCRIPTION
- support for `plan_type` and `expiry_date` fields in the plans API
- tests