### PR TITLE
AB#5425 Landscape images for plans

### DIFF
--- a/kibble/api/plans.go
+++ b/kibble/api/plans.go
@@ -62,6 +62,7 @@ func (p PlansV1) mapToModel(serviceConfig models.ServiceConfig, itemIndex models
 		PlanType:        "",
 		ExpiryDate:      p.ExpiryDate,
 		PortraitImage:   serviceConfig.ForceAbsoluteImagePath(p.PortraitImage),
+		LandscapeImage:  serviceConfig.ForceAbsoluteImagePath(p.LandscapeImage),
 		Description:     p.Description,
 		CreatedAt:       p.CreatedAt,
 		UpdatedAt:       p.UpdatedAt,
@@ -97,4 +98,5 @@ type PlansV1 struct {
 	PlanType        *string   `json:"plan_type"`
 	TrialPeriodDays *int      `json:"trial_period_days"`
 	PortraitImage   string    `json:"portrait_image"`
+	LandscapeImage  string    `json:"landscape_image"`
 }

--- a/kibble/api/plans_test.go
+++ b/kibble/api/plans_test.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 
 	"kibble/models"
@@ -64,6 +65,8 @@ func TestRecurringPlanWithExpiryDate(t *testing.T) {
 		TrialPeriodDays: &trialPeriodDays,
 		PlanType:        &planType,
 		ExpiryDate:      expiryDate,
+		PortraitImage:   "/portrait_image.png",
+		LandscapeImage:  "/landscape_image.png",
 	}
 
 	model := apiPlan.mapToModel(serviceConfig, itemIndex)
@@ -76,6 +79,9 @@ func TestRecurringPlanWithExpiryDate(t *testing.T) {
 	assert.Equal(t, 7, model.TrialPeriodDays)
 	assert.Equal(t, "recurring", model.PlanType)
 	assert.True(t, model.HasExpiryDate())
+	assert.True(t, strings.HasSuffix(model.LandscapeImage, "landscape_image.png"))
+	assert.True(t, strings.HasSuffix(model.PortraitImage, "portrait_image.png"))
+
 }
 
 func TestOneOffPlanWithNoExpiryDate(t *testing.T) {
@@ -101,4 +107,6 @@ func TestOneOffPlanWithNoExpiryDate(t *testing.T) {
 	assert.Equal(t, 0, model.TrialPeriodDays)
 	assert.Equal(t, "one_off", model.PlanType)
 	assert.False(t, model.HasExpiryDate())
+	assert.Empty(t, model.PortraitImage)
+	assert.Empty(t, model.LandscapeImage)
 }

--- a/kibble/models/plans.go
+++ b/kibble/models/plans.go
@@ -34,6 +34,7 @@ type Plan struct {
 	Page            *Page
 	PlanType        string
 	PortraitImage   string
+	LandscapeImage  string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 	ExpiryDate      time.Time


### PR DESCRIPTION
- Support for new "landscape_image" field for plans over the API which needs to reflected in the model
- Gets the image root path prepended so just checking for the filename atm
- Tests