### PR TITLE
Standardise the make behaviour

### DIFF
--- a/kibble/api/languages.go
+++ b/kibble/api/languages.go
@@ -25,15 +25,14 @@ import (
 // Loads all languages from the v1 languages API for the given site if it has the translations_api feature toggle enabled.
 func LoadAllLanguages(cfg *models.Config, site *models.Site) error {
 	if site.Toggles["translations_api"] {
-		return loadFromApi(cfg, site)
+		return loadAllLanguagesFromApi(cfg, site)
 	} else {
-		loadFromConfig(cfg, site)
+		loadAllLanguagesFromConfig(cfg, site)
 		return nil
 	}
 }
 
-func loadFromApi(cfg *models.Config, site *models.Site) error {
-
+func loadAllLanguagesFromApi(cfg *models.Config, site *models.Site) error {
 	path := fmt.Sprintf("%s/services/users/v1/languages", cfg.SiteURL)
 
 	data, err := Get(cfg, path)
@@ -95,7 +94,7 @@ func formatPathLocale(code string) string {
 	return strings.ToLower(dashedCode)
 }
 
-func loadFromConfig(cfg *models.Config, site *models.Site) {
+func loadAllLanguagesFromConfig(cfg *models.Config, site *models.Site) {
 	var keys []string
 	for k := range cfg.Languages {
 		keys = append(keys, k)

--- a/kibble/api/languages.go
+++ b/kibble/api/languages.go
@@ -18,14 +18,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"kibble/models"
+	"sort"
 	"strings"
 )
 
 // Loads all languages from the v1 languages API for the given site if it has the translations_api feature toggle enabled.
 func LoadAllLanguages(cfg *models.Config, site *models.Site) error {
-	if !site.Toggles["translations_api"] {
+	if site.Toggles["translations_api"] {
+		return loadFromApi(cfg, site)
+	} else {
+		loadFromConfig(cfg, site)
 		return nil
 	}
+}
+
+func loadFromApi(cfg *models.Config, site *models.Site) error {
 
 	path := fmt.Sprintf("%s/services/users/v1/languages", cfg.SiteURL)
 
@@ -86,4 +93,26 @@ type languageV1 struct {
 func formatPathLocale(code string) string {
 	dashedCode := strings.ReplaceAll(code, "_", "-")
 	return strings.ToLower(dashedCode)
+}
+
+func loadFromConfig(cfg *models.Config, site *models.Site) {
+	var keys []string
+	for k := range cfg.Languages {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		isDefault := k == cfg.DefaultLanguage
+		code := k
+		name := cfg.Languages[k].Name
+		if isDefault {
+			code = ""
+		}
+
+		site.Languages = append(site.Languages, models.Language{
+			IsDefault: isDefault,
+			Code:      code,
+			Name:      name,
+		})
+	}
 }

--- a/kibble/api/site.go
+++ b/kibble/api/site.go
@@ -15,8 +15,6 @@
 package api
 
 import (
-	"sort"
-
 	"kibble/models"
 	"kibble/utils"
 
@@ -46,34 +44,28 @@ func LoadSite(cfg *models.Config) (*models.Site, error) {
 	}
 
 	site := &models.Site{
-		SiteConfig: cfg,
-		Config:     config,
-		Toggles:    toggles,
-
-		// Load languages from kibble.json.
-		Languages:    sortLanguages(cfg),
+		SiteConfig:   cfg,
+		Config:       config,
+		Toggles:      toggles,
+		Languages:    make(models.LanguageCollection, 0),
 		Translations: make(models.Translations),
-
-		Navigation:  navigation,
-		Bundles:     make(models.BundleCollection, 0),
-		Collections: make(models.CollectionCollection, 0),
-		Films:       make(models.FilmCollection, 0),
-		Pages:       pages,
-		Plans:       make(models.PlanCollection, 0),
-		Taxonomies:  make(models.Taxonomies),
-		TVShows:     make(models.TVShowCollection, 0),
-		TVSeasons:   make(models.TVSeasonCollection, 0),
-		TVEpisodes:  make(models.TVEpisodeCollection, 0),
+		Navigation:   navigation,
+		Bundles:      make(models.BundleCollection, 0),
+		Collections:  make(models.CollectionCollection, 0),
+		Films:        make(models.FilmCollection, 0),
+		Pages:        pages,
+		Plans:        make(models.PlanCollection, 0),
+		Taxonomies:   make(models.Taxonomies),
+		TVShows:      make(models.TVShowCollection, 0),
+		TVSeasons:    make(models.TVSeasonCollection, 0),
+		TVEpisodes:   make(models.TVEpisodeCollection, 0),
 	}
 
-	// Loads all languages from API for given site.
-	// Overwrites result of sortLanguages function so must be called after.
 	err = LoadAllLanguages(cfg, site)
 	if err != nil {
 		return nil, err
 	}
 
-	// Loads all translations from API for given site.
 	err = LoadAllTranslations(cfg, site)
 	if err != nil {
 		return nil, err
@@ -153,30 +145,4 @@ func LoadSite(cfg *models.Config) (*models.Site, error) {
 	}
 
 	return site, nil
-}
-
-func sortLanguages(cfg *models.Config) []models.Language {
-
-	result := make([]models.Language, 0)
-
-	var keys []string
-	for k := range cfg.Languages {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		isDefault := k == cfg.DefaultLanguage
-		code := k
-		name := cfg.Languages[k].Name
-		if isDefault {
-			code = ""
-		}
-
-		result = append(result, models.Language{
-			IsDefault: isDefault,
-			Code:      code,
-			Name:      name,
-		})
-	}
-	return result
 }

--- a/kibble/models/language.go
+++ b/kibble/models/language.go
@@ -14,6 +14,9 @@
 
 package models
 
+// LanguageCollection - all languages
+type LanguageCollection []Language
+
 // Language - instance of a language
 type Language struct {
 	Code  string `json:"code"`


### PR DESCRIPTION
I didn't like how `sortLanguages()` was hung weirdly off `site` and that there is later potential overwriting - I think better to have it as a logical branch based on the toggle. I also standardised on the `FooCollection` thing same as the others.