### PR TITLE
#AB5975 - Add the ability for the builder worker to provide a SiteURL…

### DIFF
--- a/kibble/cmd/sync.go
+++ b/kibble/cmd/sync.go
@@ -53,6 +53,10 @@ var syncCmd = &cobra.Command{
 		cfg := config.LoadConfig(runAsAdmin, apiKey, disableCache)
 		config.CheckVersion(cfg)
 
+		if syncCfg.SiteURL != "" {
+			cfg.SiteURL = syncCfg.SiteURL
+		}
+
 		if testIdempotent {
 			return sync.TestIdempotent(syncCfg, cfg)
 		}
@@ -124,6 +128,7 @@ func init() {
 	syncCmd.Flags().StringVarP(&syncCfg.Region, "region", "r", "us-east-1", "AWS Region (default us-east-1)")
 	syncCmd.Flags().StringVarP(&syncCfg.Bucket, "bucket", "b", "", "AWS S3 Bucket")
 	syncCmd.Flags().StringVarP(&syncCfg.BucketRootPath, "bucketrootpath", "", "", "AWS S3 Path")
+	syncCmd.Flags().StringVarP(&syncCfg.SiteURL, "siteurl", "s", "", "Site URL")
 
 	syncCmd.Flags().BoolVarP(&renderAndSync, "render", "", false, "Renders the site before syncing.")
 	syncCmd.Flags().BoolVarP(&testIdempotent, "test-idempotent", "", false, "Checks that two runs of the render process produce the same result.")

--- a/kibble/sync/sync.go
+++ b/kibble/sync/sync.go
@@ -57,6 +57,7 @@ type Config struct {
 	Bucket         string
 	BucketRootPath string
 	FileRootPath   string
+	SiteURL        string
 }
 
 // Store - a place to store the site files


### PR DESCRIPTION
… parameter when doing a sync. This will allow us to build several sites using the same template by allowing the sync to be passed the domain of the site rather than use the siteURL in the kibble.json