### PR TITLE
Plans add prices AB#6483

### DIFF
--- a/kibble/api/plans.go
+++ b/kibble/api/plans.go
@@ -45,6 +45,8 @@ func LoadAllPlans(cfg *models.Config, site *models.Site, itemIndex models.ItemIn
 		plan.LinkPlanToPage(site, b.PageID)
 
 		site.Plans = append(site.Plans, plan)
+
+		itemIndex.Set(plan.Slug, plan.GetGenericItem())
 	}
 
 	return nil

--- a/kibble/api/prices.go
+++ b/kibble/api/prices.go
@@ -131,10 +131,6 @@ func processPrices(details prices, site *models.Site, itemIndex models.ItemIndex
 
 type prices struct {
 	Prices []pricesV2 `json:"prices"`
-	Plans  []struct {
-		Item    string
-		Plans   []string
-	} `json:"plans"`
 }
 
 type pricesV2 struct {

--- a/kibble/api/prices.go
+++ b/kibble/api/prices.go
@@ -32,6 +32,10 @@ func LoadAllPrices(cfg *models.Config, site *models.Site, itemIndex models.ItemI
 		slugs = append(slugs, k)
 	}
 
+	for k := range itemIndex["plan"] {
+		slugs = append(slugs, k)
+	}
+
 	sort.Strings(slugs)
 
 	const batchSize = 300
@@ -112,6 +116,13 @@ func processPrices(details prices, site *models.Site, itemIndex models.ItemIndex
 				// replace the itemIndex
 				itemIndex.Replace(p.Item, f.GetGenericItem())
 			}
+		case "plan":
+			if f, err := site.Plans.FindPlanBySlug(p.Item); err == nil {
+				count++
+				f.Prices = pricingInfo
+				// replace the itemIndex
+				itemIndex.Replace(p.Item, f.GetGenericItem())
+			}
 		}
 	}
 
@@ -120,7 +131,10 @@ func processPrices(details prices, site *models.Site, itemIndex models.ItemIndex
 
 type prices struct {
 	Prices []pricesV2 `json:"prices"`
-	// Plans  []interface{} `json:"plans"`
+	Plans  []struct {
+		Item    string
+		Plans   []string
+	} `json:"plans"`
 }
 
 type pricesV2 struct {

--- a/kibble/api/prices_test.go
+++ b/kibble/api/prices_test.go
@@ -89,15 +89,6 @@ func TestMergePrices(t *testing.T) {
 				},
 			},
 		},
-		Plans: []struct{
-			Item string
-			Plans []string
-		}{
-			{
-				"/film/103",
-				[]string{"/plan/1","/plan/2"},
-			},
-		},
 }
 
 

--- a/kibble/models/item_index_test.go
+++ b/kibble/models/item_index_test.go
@@ -57,6 +57,18 @@ func TestAddingTVShowToItemIndex(t *testing.T) {
 	assert.Equal(t, Unresolved, itemIndex.Get("/tv/123"), "expect item to be Unresolved")
 }
 
+func TestAddingPlanToItemIndex(t *testing.T) {
+
+	itemIndex := make(ItemIndex)
+
+	itemIndex.MapToUnresolvedItems([]string{"/plan/123"})
+
+	assert.Equal(t, 1, len(itemIndex["plan"]), "expect item index to include the plan")
+	assert.Equal(t, Unresolved, itemIndex["plan"]["/plan/123"], "expect item to be unresolved")
+	assert.Equal(t, false, itemIndex["plan"]["/plan/123"].IsResolved(), "expect item to be IsResolved() == false")
+	assert.Equal(t, Unresolved, itemIndex.Get("/plan/123"), "expect item to be Unresolved")
+}
+
 func TestLinkingBundlesItems(t *testing.T) {
 
 	itemIndex := make(ItemIndex)

--- a/kibble/models/plans.go
+++ b/kibble/models/plans.go
@@ -38,6 +38,7 @@ type Plan struct {
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 	ExpiryDate      time.Time
+	Prices          PriceInfo
 }
 
 func (plan *Plan) LinkPlanToPage(site *Site, PageID int) {
@@ -56,4 +57,24 @@ func (plan *Plan) LinkPlanToPage(site *Site, PageID int) {
 
 func (plan *Plan) HasExpiryDate() bool {
 	return !plan.ExpiryDate.IsZero()
+}
+
+// GetGenericItem - returns a generic item
+func (plan Plan) GetGenericItem() GenericItem {
+	return GenericItem{
+		Slug:      plan.Slug,
+		ItemType:  "plan",
+		InnerItem: plan,
+	}
+}
+
+// FindPlanBySlug - find the plan by the slug
+func (plans *PlanCollection) FindPlanBySlug(slug string) (*Plan, error) {
+	coll := *plans
+	for i := 0; i < len(coll); i++ {
+		if coll[i].Slug == slug {
+			return &coll[i], nil
+		}
+	}
+	return nil, ErrDataSourceMissing
 }


### PR DESCRIPTION
Kibble currently gets pricing for films, tv etc, but not plans.

This PR makes it so in the template, we could go `site.Plans[0].Prices` for example (not that we need to)

The actual reason for this PR is:
- We're rolling out a video feed for every client ([example](https://homecinema.curzon.com/videos.json)).
- In the feed, we need to get the lowest price for each film, including plan prices. Or lowest plan price if film price is zero.
- This is just the first step to this. (broken out in order to make pull requests smaller. Step two will be to add these plan prices onto a film)

