### PR TITLE
Add status id to films

### DIFF
--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -56,7 +56,9 @@ func AppendAllFilms(cfg *models.Config, site *models.Site, itemIndex models.Item
 	}
 
 	for i := 0; i < len(summary); i++ {
-		itemIndex.Set(fmt.Sprintf("/film/%d", summary[i].ID), models.Unresolved)
+		itemIndex.SetWithStatus(fmt.Sprintf("/film/%d", summary[i].ID), summary[i].StatusID, models.Unresolved)
+		//itemIndex.Set(fmt.Sprintf("/film/%d", summary[i].ID), models.Unresolved)
+		//log.Errorf("Status ID: %s", summary[i].StatusID)
 	}
 
 	return nil
@@ -104,8 +106,8 @@ func AppendFilms(cfg *models.Config, site *models.Site, slugs []string, itemInde
 
 			f := film.mapToModel(site.Config, itemIndex)
 			site.Films = append(site.Films, f)
+			//itemIndex.SetWithStatus(f.Slug, f.StatusID, f.GetGenericItem())
 			itemIndex.Set(f.Slug, f.GetGenericItem())
-
 		} else {
 			log.Error("film.error: %s", err)
 			log.Debug("invalid data %s", string(details[i]))
@@ -122,6 +124,7 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 		Slug:            f.Slug,
 		Title:           f.Title,
 		TitleSlug:       slug.Make(f.Title),
+		StatusID:        itemIndex.Get(f.Slug).StatusID,
 		Overview:        f.Overview,
 		Tagline:         f.Tagline,
 		ReleaseDate:     utils.ParseTimeFromString(f.ReleaseDate),
@@ -157,6 +160,10 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 		},
 		Subtitles: f.Subtitles,
 	}
+
+	log.Errorf("Index return: %d", itemIndex.Get(f.Slug).StatusID)
+	itemIndex.Print()
+	itemIndex.PrintStats()
 
 	for _, s := range f.Studio {
 		film.Studio = append(film.Studio, s.Name)

--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -56,9 +56,9 @@ func AppendAllFilms(cfg *models.Config, site *models.Site, itemIndex models.Item
 	}
 
 	for i := 0; i < len(summary); i++ {
+
 		itemIndex.SetWithStatus(fmt.Sprintf("/film/%d", summary[i].ID), summary[i].StatusID, models.Unresolved)
-		//itemIndex.Set(fmt.Sprintf("/film/%d", summary[i].ID), models.Unresolved)
-		//log.Errorf("Status ID: %s", summary[i].StatusID)
+
 	}
 
 	return nil
@@ -66,7 +66,6 @@ func AppendAllFilms(cfg *models.Config, site *models.Site, itemIndex models.Item
 
 // AppendFilms - load a list of films
 func AppendFilms(cfg *models.Config, site *models.Site, slugs []string, itemIndex models.ItemIndex) error {
-
 	sort.Strings(slugs)
 
 	if len(slugs) > 300 {
@@ -106,8 +105,8 @@ func AppendFilms(cfg *models.Config, site *models.Site, slugs []string, itemInde
 
 			f := film.mapToModel(site.Config, itemIndex)
 			site.Films = append(site.Films, f)
-			//itemIndex.SetWithStatus(f.Slug, f.StatusID, f.GetGenericItem())
-			itemIndex.Set(f.Slug, f.GetGenericItem())
+			itemIndex.Replace(f.Slug, f.GetGenericItem())
+
 		} else {
 			log.Error("film.error: %s", err)
 			log.Debug("invalid data %s", string(details[i]))
@@ -160,10 +159,6 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 		},
 		Subtitles: f.Subtitles,
 	}
-
-	log.Errorf("Index return: %d", itemIndex.Get(f.Slug).StatusID)
-	itemIndex.Print()
-	itemIndex.PrintStats()
 
 	for _, s := range f.Studio {
 		film.Studio = append(film.Studio, s.Name)

--- a/kibble/models/film.go
+++ b/kibble/models/film.go
@@ -28,6 +28,7 @@ type Film struct {
 	Slug            string
 	Title           string
 	TitleSlug       string
+	StatusID        int
 	Trailers        []Trailer
 	Bonuses         BonusContentCollection
 	Cast            []CastMember
@@ -87,6 +88,7 @@ func (film Film) GetGenericItem() GenericItem {
 		Images:    film.Images,
 		ItemType:  "film",
 		InnerItem: film,
+		StatusID:  film.StatusID,
 	}
 }
 

--- a/kibble/models/generic_item.go
+++ b/kibble/models/generic_item.go
@@ -26,6 +26,7 @@ type GenericItem struct {
 	Title    string
 	Images   ImageSet
 	Seo      Seo
+	StatusID int
 }
 
 // GetTitle - returns the title in the current language

--- a/kibble/models/item_index.go
+++ b/kibble/models/item_index.go
@@ -100,10 +100,6 @@ func (itemIndex ItemIndex) SetWithStatus(slug string, statusID int, item Generic
 	if (ok && (foundItem == Unresolved || foundItem == Empty)) || !ok {
 		index[slug] = item
 	}
-	// itemIndex.Print()
-	// itemIndex.PrintStats()
-	// log.Errorf("Setting status ID: status id recieved %d, vs item.Status: %d", statusID, item.StatusID)
-	// log.Errorf("Item: %s", index[slug])
 }
 
 // Replace a value in the index
@@ -148,12 +144,17 @@ func (itemIndex ItemIndex) findSlugsOfType(slugType string, itemType GenericItem
 	t, ok := itemIndex[slugType]
 	if ok {
 		for k, v := range t {
-			if v == itemType {
+			if deepCompare(v, itemType) {
 				found = append(found, k)
 			}
 		}
 	}
 	return found
+}
+
+//Checking StatusID (which may be set) against generic Item type will cause fail check against all other feilds
+func deepCompare(a GenericItem, b GenericItem) bool {
+	return a.Slug == b.Slug && a.ItemType == b.ItemType && a.Title == b.Title && a.Images == b.Images && a.Seo == b.Seo
 }
 
 // LinkItems - link the items to the specific parts
@@ -199,7 +200,6 @@ func (itemIndex ItemIndex) Print() {
 	for t, val := range itemIndex {
 		log.Infof("type: %s", t)
 		for k, v := range val {
-			log.Infof("Value of status id: ", v.StatusID)
 			if v == Empty {
 				log.Infof("%s - %s : empty", t, k)
 			} else if v == Unresolved {

--- a/kibble/models/item_index.go
+++ b/kibble/models/item_index.go
@@ -83,6 +83,29 @@ func (itemIndex ItemIndex) Set(slug string, item GenericItem) {
 	}
 }
 
+// Set - an item
+func (itemIndex ItemIndex) SetWithStatus(slug string, statusID int, item GenericItem) {
+
+	slugType := getSlugType(slug)
+
+	index, ok := itemIndex[slugType]
+	if !ok {
+		itemIndex[slugType] = make(map[string]GenericItem)
+		index = itemIndex[slugType]
+	}
+
+	// unresolved can be overwritten, empty and item can not
+	foundItem, ok := index[slug]
+	item.StatusID = statusID
+	if (ok && (foundItem == Unresolved || foundItem == Empty)) || !ok {
+		index[slug] = item
+	}
+	// itemIndex.Print()
+	// itemIndex.PrintStats()
+	// log.Errorf("Setting status ID: status id recieved %d, vs item.Status: %d", statusID, item.StatusID)
+	// log.Errorf("Item: %s", index[slug])
+}
+
 // Replace a value in the index
 func (itemIndex ItemIndex) Replace(slug string, item GenericItem) {
 
@@ -176,6 +199,7 @@ func (itemIndex ItemIndex) Print() {
 	for t, val := range itemIndex {
 		log.Infof("type: %s", t)
 		for k, v := range val {
+			log.Infof("Value of status id: ", v.StatusID)
 			if v == Empty {
 				log.Infof("%s - %s : empty", t, k)
 			} else if v == Unresolved {

--- a/kibble/models/item_index.go
+++ b/kibble/models/item_index.go
@@ -152,7 +152,7 @@ func (itemIndex ItemIndex) findSlugsOfType(slugType string, itemType GenericItem
 	return found
 }
 
-//Checking StatusID (which may be set) against generic Item type will cause fail check against all other feilds
+//Check fields of GenericItem, ignore StatusID (publish status) as it may differ.
 func deepCompare(a GenericItem, b GenericItem) bool {
 	return a.Slug == b.Slug && a.ItemType == b.ItemType && a.Title == b.Title && a.Images == b.Images && a.Seo == b.Seo
 }


### PR DESCRIPTION
AB#5851 Part of the work to get draft indicators onto unpublished films on the admin front end, added the status ID to the generic Item, that is pulled from the /film/index api