### PR TITLE
Remove readme from archive

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 0.16.3
+Fix to the release process - no changes from 0.16.2.
+
 ## 0.16.2
 Added CSS API call.
 Added CSSFilename to Site model.

--- a/kibble-npm/package.json
+++ b/kibble-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s72-kibble",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "SHIFT72 static site generator",
   "preferGlobal": false,
   "main": "index.js",

--- a/kibble/.goreleaser.yml
+++ b/kibble/.goreleaser.yml
@@ -17,8 +17,6 @@ archives:
     amd64: 64-bit
     darwin: macOS
     linux: Tux
-  files:
-    - ../readme.md
   format_overrides:
     - goos: windows
       format: zip


### PR DESCRIPTION
Using latest version of goreleaser:

```
goreleaser -v
goreleaser version 1.4.1
commit: a1447a363579365f489458ad7636fd088a5b66ab
built at: 2022-01-27T03:23:37Z
built by: goreleaser
goos: linux
goarch: amd64
module version: v1.4.1, checksum: h1:gW8sdjDEo2H2ZgcJmWsNZUcaJSD4MLvA/bw7+GYQ8kU=

https://goreleaser.com
```

... has a problem with the relative path to include the readme in the archive.

![image](https://user-images.githubusercontent.com/2253814/153516197-1e1ecd6a-a154-4b8a-82ba-e2770a621baf.png)

Error looks to be coming from [this line](https://github.com/goreleaser/fileglob/blob/c593736e3f4cace42c8e354260fa96c16d39ddd3/glob.go#L147) in goreleaser. I'm going to take the easy way out and not include the file.
