### PR TITLE
Suppress goreleaser hook errors for non-linux

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 0.16.4
+Fix to the release process - no changes from 0.16.2.
+
 ## 0.16.3
 Fix to the release process - no changes from 0.16.2.
 

--- a/kibble-npm/package.json
+++ b/kibble-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s72-kibble",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "SHIFT72 static site generator",
   "preferGlobal": false,
   "main": "index.js",

--- a/kibble/.goreleaser.yml
+++ b/kibble/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
       - amd64
     ldflags: -s -w -X kibble/version.Version={{.Version}}
     hooks:
-      post: sh ./deploy_aws.sh {{.Version}}
+      post: sh ./deploy_aws.sh {{.Version}} {{.Os}}
 
 archives:
 - id: main

--- a/kibble/deploy_aws.sh
+++ b/kibble/deploy_aws.sh
@@ -1,7 +1,19 @@
-VERSION=$(git describe --tags)
+VERSION=$1
+OS=$2
+
 if [ -z $VERSION ]; then
-  echo "error: tagged version not found"
+  echo "error: version not specified"
   exit 1
+fi
+
+if [ -z $OS ]; then
+  echo "error: OS not specified"
+  exit 1
+fi
+
+if [ $OS != "linux" ]; then
+  echo "Skipping hook for $OS"
+  exit 0
 fi
 
 echo "uploading linux only version - $VERSION"


### PR DESCRIPTION
Fixes #103.

1. Uses version already determined by goreleaser.
2. The hook now checks the OS so it can exit early for non-linux and not try to upload a file that doesn't exist.

@sarge @additiverich @gscragg @PeculiarGoat 