### PR TITLE
Added error in StartLiveReload

### DIFF
--- a/kibble/render/render.go
+++ b/kibble/render/render.go
@@ -43,7 +43,11 @@ func Watch(sourcePath string, buildPath string, cfg *models.Config, port int32, 
 	liveReload.StartLiveReload(port, func() {
 		// re-render
 		logReader.Clear()
-		Render(sourcePath, buildPath, cfg)
+		err := Render(sourcePath, buildPath, cfg)
+		if err > 0 {
+			log.Errorf("Error in Render, LiveReload exiting")
+			os.Exit(1)
+		}
 	})
 
 	proxy := NewProxy(cfg.SiteURL, cfg.ProxyPatterns)


### PR DESCRIPTION
[AB#6791](https://dev.azure.com/S72/fefacba9-96b6-4af2-a53d-050ed453e13a/_workitems/edit/6791) Kill Render on Error
Needed to stop Error messages from printing to screen and continuing to render the site, will kill the process so developer is forced to face problem