### PR TITLE
AB#5032 Images as a map rather than a struct

### DIFF
--- a/kibble/api/bonus_content.go
+++ b/kibble/api/bonus_content.go
@@ -56,3 +56,38 @@ func (bcv2 bonusContentV2) mapToModel2(parentSlug string, parentImages models.Im
 	return b
 
 }
+
+// For parent models which use the ImageMap rather than ImageSet
+func (bcv2 bonusContentV2) mapToModel3(parentSlug string, parentImages models.ImageMap) models.BonusContent {
+
+	// Convert the ImageMap to an ImageSet (which we will eventually phase out)
+	images := models.ImageMapToImageSet(parentImages)
+	images.Portrait = utils.Coalesce(bcv2.ImageUrls.Portrait, images.Portrait)
+	images.Landscape = utils.Coalesce(bcv2.ImageUrls.Landscape, images.Landscape)
+	images.Header = utils.Coalesce(bcv2.ImageUrls.Header, images.Header)
+	images.Carousel = utils.Coalesce(bcv2.ImageUrls.Carousel, images.Carousel)
+	images.Background = utils.Coalesce(bcv2.ImageUrls.Bg, images.Background)
+	images.Classification = utils.Coalesce(bcv2.ImageUrls.Classification, images.Classification)
+
+	b := models.BonusContent{
+		Slug:         fmt.Sprintf("%s/bonus/%d", parentSlug, bcv2.Number),
+		Number:       bcv2.Number,
+		Title:        bcv2.Title,
+		Runtime:      models.Runtime(bcv2.Runtime),
+		Overview:     bcv2.Overview,
+		Images:       images,
+		CustomFields: bcv2.CustomFields,
+	}
+
+	for _, t := range bcv2.SubtitleTracks {
+		b.SubtitleTracks = append(b.SubtitleTracks, models.SubtitleTrack{
+			Language: t.Language,
+			Name:     t.Name,
+			Type:     t.Type,
+			Path:     t.Path,
+		})
+	}
+
+	return b
+
+}

--- a/kibble/api/bonus_content.go
+++ b/kibble/api/bonus_content.go
@@ -58,28 +58,28 @@ func (bcv2 bonusContentV2) mapToModel2(parentSlug string, parentImages models.Im
 }
 
 // For parent models which use the ImageMap rather than ImageSet
-func (bcv2 bonusContentV2) mapToModel3(parentSlug string, parentImages models.ImageMap) models.BonusContent {
+func (bc bonusContentV2) mapToModel3(parentSlug string, parentImages models.ImageMap) models.BonusContent {
 
 	// Convert the ImageMap to an ImageSet (which we will eventually phase out)
 	images := models.ImageMapToImageSet(parentImages)
-	images.Portrait = utils.Coalesce(bcv2.ImageUrls.Portrait, images.Portrait)
-	images.Landscape = utils.Coalesce(bcv2.ImageUrls.Landscape, images.Landscape)
-	images.Header = utils.Coalesce(bcv2.ImageUrls.Header, images.Header)
-	images.Carousel = utils.Coalesce(bcv2.ImageUrls.Carousel, images.Carousel)
-	images.Background = utils.Coalesce(bcv2.ImageUrls.Bg, images.Background)
-	images.Classification = utils.Coalesce(bcv2.ImageUrls.Classification, images.Classification)
+	images.Portrait = utils.Coalesce(bc.ImageUrls.Portrait, images.Portrait)
+	images.Landscape = utils.Coalesce(bc.ImageUrls.Landscape, images.Landscape)
+	images.Header = utils.Coalesce(bc.ImageUrls.Header, images.Header)
+	images.Carousel = utils.Coalesce(bc.ImageUrls.Carousel, images.Carousel)
+	images.Background = utils.Coalesce(bc.ImageUrls.Bg, images.Background)
+	images.Classification = utils.Coalesce(bc.ImageUrls.Classification, images.Classification)
 
 	b := models.BonusContent{
-		Slug:         fmt.Sprintf("%s/bonus/%d", parentSlug, bcv2.Number),
-		Number:       bcv2.Number,
-		Title:        bcv2.Title,
-		Runtime:      models.Runtime(bcv2.Runtime),
-		Overview:     bcv2.Overview,
+		Slug:         fmt.Sprintf("%s/bonus/%d", parentSlug, bc.Number),
+		Number:       bc.Number,
+		Title:        bc.Title,
+		Runtime:      models.Runtime(bc.Runtime),
+		Overview:     bc.Overview,
 		Images:       images,
-		CustomFields: bcv2.CustomFields,
+		CustomFields: bc.CustomFields,
 	}
 
-	for _, t := range bcv2.SubtitleTracks {
+	for _, t := range bc.SubtitleTracks {
 		b.SubtitleTracks = append(b.SubtitleTracks, models.SubtitleTrack{
 			Language: t.Language,
 			Name:     t.Name,

--- a/kibble/api/bonus_content.go
+++ b/kibble/api/bonus_content.go
@@ -25,57 +25,22 @@ type bonusContentV2 struct {
 	CustomFields   map[string]interface{} `json:"custom"`
 }
 
-func (bcv2 bonusContentV2) mapToModel2(parentSlug string, parentImages models.ImageSet) models.BonusContent {
+func (bc bonusContentV2) mapToModel2(parentSlug string, parentImages models.ImageSet) models.BonusContent {
 
 	b := models.BonusContent{
-		Slug:     fmt.Sprintf("%s/bonus/%d", parentSlug, bcv2.Number),
-		Number:   bcv2.Number,
-		Title:    bcv2.Title,
-		Runtime:  models.Runtime(bcv2.Runtime),
-		Overview: bcv2.Overview,
+		Slug:     fmt.Sprintf("%s/bonus/%d", parentSlug, bc.Number),
+		Number:   bc.Number,
+		Title:    bc.Title,
+		Runtime:  models.Runtime(bc.Runtime),
+		Overview: bc.Overview,
 		Images: models.ImageSet{
-			Portrait:       utils.Coalesce(bcv2.ImageUrls.Portrait, parentImages.Portrait),
-			Landscape:      utils.Coalesce(bcv2.ImageUrls.Landscape, parentImages.Landscape),
-			Header:         utils.Coalesce(bcv2.ImageUrls.Header, parentImages.Header),
-			Carousel:       utils.Coalesce(bcv2.ImageUrls.Carousel, parentImages.Carousel),
-			Background:     utils.Coalesce(bcv2.ImageUrls.Bg, parentImages.Background),
-			Classification: utils.Coalesce(bcv2.ImageUrls.Classification, parentImages.Classification),
+			Portrait:       utils.Coalesce(bc.ImageUrls.Portrait, parentImages.Portrait),
+			Landscape:      utils.Coalesce(bc.ImageUrls.Landscape, parentImages.Landscape),
+			Header:         utils.Coalesce(bc.ImageUrls.Header, parentImages.Header),
+			Carousel:       utils.Coalesce(bc.ImageUrls.Carousel, parentImages.Carousel),
+			Background:     utils.Coalesce(bc.ImageUrls.Bg, parentImages.Background),
+			Classification: utils.Coalesce(bc.ImageUrls.Classification, parentImages.Classification),
 		},
-		CustomFields: bcv2.CustomFields,
-	}
-
-	for _, t := range bcv2.SubtitleTracks {
-		b.SubtitleTracks = append(b.SubtitleTracks, models.SubtitleTrack{
-			Language: t.Language,
-			Name:     t.Name,
-			Type:     t.Type,
-			Path:     t.Path,
-		})
-	}
-
-	return b
-
-}
-
-// For parent models which use the ImageMap rather than ImageSet
-func (bc bonusContentV2) mapToModel3(parentSlug string, parentImages models.ImageMap) models.BonusContent {
-
-	// Convert the ImageMap to an ImageSet (which we will eventually phase out)
-	images := models.ImageMapToImageSet(parentImages)
-	images.Portrait = utils.Coalesce(bc.ImageUrls.Portrait, images.Portrait)
-	images.Landscape = utils.Coalesce(bc.ImageUrls.Landscape, images.Landscape)
-	images.Header = utils.Coalesce(bc.ImageUrls.Header, images.Header)
-	images.Carousel = utils.Coalesce(bc.ImageUrls.Carousel, images.Carousel)
-	images.Background = utils.Coalesce(bc.ImageUrls.Bg, images.Background)
-	images.Classification = utils.Coalesce(bc.ImageUrls.Classification, images.Classification)
-
-	b := models.BonusContent{
-		Slug:         fmt.Sprintf("%s/bonus/%d", parentSlug, bc.Number),
-		Number:       bc.Number,
-		Title:        bc.Title,
-		Runtime:      models.Runtime(bc.Runtime),
-		Overview:     bc.Overview,
-		Images:       images,
 		CustomFields: bc.CustomFields,
 	}
 

--- a/kibble/api/bonus_content_test.go
+++ b/kibble/api/bonus_content_test.go
@@ -53,7 +53,7 @@ func TestBonusContentImagesUseFilmImagesAsFallback(t *testing.T) {
 			Number: 1,
 			Title:  "Behind the scenes",
 		}},
-		ImageUrls: map[string]interface{}{
+		ImageUrls: map[string]string{
 			"portrait_image":       "film-portrait.jpeg",
 			"landscape_image":      "film-landscape.jpeg",
 			"header_image":         "film-header.jpeg",

--- a/kibble/api/bonus_content_test.go
+++ b/kibble/api/bonus_content_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"kibble/models"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,22 +53,14 @@ func TestBonusContentImagesUseFilmImagesAsFallback(t *testing.T) {
 			Number: 1,
 			Title:  "Behind the scenes",
 		}},
-		ImageUrls: struct {
-			Portrait       string `json:"portrait"`
-			Landscape      string `json:"landscape"`
-			Header         string `json:"header"`
-			Carousel       string `json:"carousel"`
-			Bg             string `json:"bg"`
-			Classification string `json:"classification"`
-			Seo            string `json:"seo"`
-		}{
-			Portrait:       "film-portrait.jpeg",
-			Landscape:      "film-landscape.jpeg",
-			Header:         "film-header.jpeg",
-			Carousel:       "film-carousel.jpeg",
-			Bg:             "film-background.jpeg",
-			Classification: "film-classification.jpeg",
-			Seo:            "film-seo.jpeg",
+		ImageUrls: map[string]interface{}{
+			"portrait_image":       "film-portrait.jpeg",
+			"landscape_image":      "film-landscape.jpeg",
+			"header_image":         "film-header.jpeg",
+			"carousel_image":       "film-carousel.jpeg",
+			"bg_image":             "film-background.jpeg",
+			"classification_image": "film-classification.jpeg",
+			"seo_image":            "film-seo.jpeg",
 		},
 	}
 

--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -236,7 +236,7 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 
 	// add bonuses - supports linking to bonus entries (supported??)
 	for _, bonus := range f.Bonuses {
-		b := bonus.mapToModel3(film.Slug, film.ImageMap)
+		b := bonus.mapToModel2(film.Slug, film.Images)
 		film.Bonuses = append(film.Bonuses, b)
 		itemIndex.Set(b.Slug, b.GetGenericItem())
 	}

--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -118,6 +118,33 @@ func AppendFilms(cfg *models.Config, site *models.Site, slugs []string, itemInde
 
 func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.ItemIndex) models.Film {
 
+	// Convert 'foo_image' or 'foo' to 'Foo'
+	for key, value := range f.ImageUrls {
+		// Special case
+		if (key == "bg") || (key == "bg_image") {
+			key = "background"
+		}
+
+		titleCaseKey := strings.Title(strings.ToLower(key))
+		titleCaseKey = strings.Replace(titleCaseKey, "_image", "", -1)
+
+		if titleCaseKey != key {
+			f.ImageUrls[titleCaseKey] = value
+			delete(f.ImageUrls, key)
+		}
+	}
+
+	// A couple of defaults used to fallback on
+	landscapeImage := ""
+	if f.ImageUrls["Landscape"] != nil {
+		landscapeImage = f.ImageUrls["Landscape"].(string)
+	}
+
+	portraitImage := ""
+	if f.ImageUrls["Portrait"] != nil {
+		portraitImage = f.ImageUrls["Portrait"].(string)
+	}
+
 	film := models.Film{
 		ID:              f.ID,
 		Slug:            f.Slug,
@@ -138,17 +165,9 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 			Title:       serviceConfig.GetSEOTitle(f.SeoTitle, f.Title),
 			Keywords:    serviceConfig.GetKeywords(f.SeoKeywords),
 			Description: utils.Coalesce(f.SeoDescription, f.Tagline),
-			Image:       serviceConfig.SelectDefaultImageType(f.ImageUrls.Landscape, f.ImageUrls.Portrait),
+			Image:       serviceConfig.SelectDefaultImageType(landscapeImage, portraitImage),
 		},
-		Images: models.ImageSet{
-			Portrait:       f.ImageUrls.Portrait,
-			Landscape:      f.ImageUrls.Landscape,
-			Header:         f.ImageUrls.Header,
-			Carousel:       f.ImageUrls.Carousel,
-			Background:     f.ImageUrls.Bg,
-			Classification: f.ImageUrls.Classification,
-			Seo:            f.ImageUrls.Seo,
-		},
+		Images:          f.ImageUrls,
 		Recommendations: itemIndex.MapToUnresolvedItems(f.Recommendations),
 		Trailers:        make([]models.Trailer, 0),
 		Cast:            make([]models.CastMember, 0),
@@ -207,7 +226,7 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 		film.AwardCategories = append(film.AwardCategories, models.AwardCategory{
 			Title:        t.Title,
 			DisplayLabel: t.DisplayLabel,
-			IsWinner:       t.IsWinner,
+			IsWinner:     t.IsWinner,
 		})
 	}
 
@@ -221,14 +240,15 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 
 	// add bonuses - supports linking to bonus entries (supported??)
 	for _, bonus := range f.Bonuses {
-		b := bonus.mapToModel2(film.Slug, film.Images)
+		b := bonus.mapToModel3(film.Slug, film.Images)
 		film.Bonuses = append(film.Bonuses, b)
 		itemIndex.Set(b.Slug, b.GetGenericItem())
 	}
 
 	// if seo image is available, use it
-	if len(film.Images.Seo) > 0 {
-		film.Seo.Image = film.Images.Seo
+	seo_image := film.Images["Seo"]
+	if (seo_image != nil) && (len(seo_image.(string)) > 0) {
+		film.Seo.Image = seo_image.(string)
 	}
 
 	return film
@@ -252,27 +272,19 @@ type filmV2 struct {
 	Studio []struct {
 		Name string `json:"name"`
 	} `json:"studio"`
-	Overview    string   `json:"overview"`
-	Tagline     string   `json:"tagline"`
-	ReleaseDate string   `json:"release_date,omitempty"`
-	Runtime     float64  `json:"runtime"`
-	Countries   []string `json:"countries"`
-	Languages   []string `json:"languages"`
-	Genres      []string `json:"genres"`
-	Tags        []string `json:"tags"`
-	Title       string   `json:"title"`
-	Slug        string   `json:"slug"`
-	FilmID      int      `json:"film_id"`
-	ID          int      `json:"id"`
-	ImageUrls   struct {
-		Portrait       string `json:"portrait"`
-		Landscape      string `json:"landscape"`
-		Header         string `json:"header"`
-		Carousel       string `json:"carousel"`
-		Bg             string `json:"bg"`
-		Classification string `json:"classification"`
-		Seo            string `json:"seo"`
-	} `json:"image_urls"`
+	Overview        string                      `json:"overview"`
+	Tagline         string                      `json:"tagline"`
+	ReleaseDate     string                      `json:"release_date,omitempty"`
+	Runtime         float64                     `json:"runtime"`
+	Countries       []string                    `json:"countries"`
+	Languages       []string                    `json:"languages"`
+	Genres          []string                    `json:"genres"`
+	Tags            []string                    `json:"tags"`
+	Title           string                      `json:"title"`
+	Slug            string                      `json:"slug"`
+	FilmID          int                         `json:"film_id"`
+	ID              int                         `json:"id"`
+	ImageUrls       map[string]interface{}      `json:"image_urls"`
 	Recommendations []string                    `json:"recommendations"`
 	Subtitles       []string                    `json:"subtitles"`
 	SubtitleTracks  []subtitleTrackV1           `json:"subtitle_tracks"`

--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -135,15 +135,9 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 	}
 
 	// A couple of defaults used to fallback on
-	landscapeImage := ""
-	if f.ImageUrls["Landscape"] != nil {
-		landscapeImage = f.ImageUrls["Landscape"].(string)
-	}
+	landscapeImage := f.ImageUrls["Landscape"]
 
-	portraitImage := ""
-	if f.ImageUrls["Portrait"] != nil {
-		portraitImage = f.ImageUrls["Portrait"].(string)
-	}
+	portraitImage := f.ImageUrls["Portrait"]
 
 	film := models.Film{
 		ID:              f.ID,
@@ -248,10 +242,7 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 	}
 
 	// if seo image is available, use it
-	seo_image := film.ImageMap["Seo"]
-	if (seo_image != nil) && (len(seo_image.(string)) > 0) {
-		film.Seo.Image = seo_image.(string)
-	}
+	film.Seo.Image = film.ImageMap["Seo"]
 
 	return film
 }
@@ -286,7 +277,7 @@ type filmV2 struct {
 	Slug            string                      `json:"slug"`
 	FilmID          int                         `json:"film_id"`
 	ID              int                         `json:"id"`
-	ImageUrls       map[string]interface{}      `json:"image_urls"`
+	ImageUrls       map[string]string           `json:"image_urls"`
 	Recommendations []string                    `json:"recommendations"`
 	Subtitles       []string                    `json:"subtitles"`
 	SubtitleTracks  []subtitleTrackV1           `json:"subtitle_tracks"`

--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -241,7 +241,6 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 		itemIndex.Set(b.Slug, b.GetGenericItem())
 	}
 
-	// if seo image is available, use it
 	film.Seo.Image = film.ImageMap["Seo"]
 
 	return film

--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -167,7 +167,7 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 			Description: utils.Coalesce(f.SeoDescription, f.Tagline),
 			Image:       serviceConfig.SelectDefaultImageType(landscapeImage, portraitImage),
 		},
-		Images:          f.ImageUrls,
+		ImageMap:        f.ImageUrls,
 		Recommendations: itemIndex.MapToUnresolvedItems(f.Recommendations),
 		Trailers:        make([]models.Trailer, 0),
 		Cast:            make([]models.CastMember, 0),
@@ -178,6 +178,8 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 		},
 		Subtitles: f.Subtitles,
 	}
+
+	film.Images = models.ImageMapToImageSet(film.ImageMap)
 
 	for _, s := range f.Studio {
 		film.Studio = append(film.Studio, s.Name)
@@ -240,13 +242,13 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 
 	// add bonuses - supports linking to bonus entries (supported??)
 	for _, bonus := range f.Bonuses {
-		b := bonus.mapToModel3(film.Slug, film.Images)
+		b := bonus.mapToModel3(film.Slug, film.ImageMap)
 		film.Bonuses = append(film.Bonuses, b)
 		itemIndex.Set(b.Slug, b.GetGenericItem())
 	}
 
 	// if seo image is available, use it
-	seo_image := film.Images["Seo"]
+	seo_image := film.ImageMap["Seo"]
 	if (seo_image != nil) && (len(seo_image.(string)) > 0) {
 		film.Seo.Image = seo_image.(string)
 	}

--- a/kibble/api/films_test.go
+++ b/kibble/api/films_test.go
@@ -134,11 +134,7 @@ func getFilm() filmV2 {
 			DisplayLabel: "The Award 2021",
 			IsWinner:     true,
 		}},
-		ImageUrls: map[string]interface{}{
-			"portrait_image":       nil,
-			"landscape_image":      nil,
-			"classification_image": nil,
-		},
+		ImageUrls: map[string]interface{}{},
 	}
 	return apiFilm
 }

--- a/kibble/api/films_test.go
+++ b/kibble/api/films_test.go
@@ -134,6 +134,11 @@ func getFilm() filmV2 {
 			DisplayLabel: "The Award 2021",
 			IsWinner:     true,
 		}},
+		ImageUrls: map[string]interface{}{
+			"portrait_image":       nil,
+			"landscape_image":      nil,
+			"classification_image": nil,
+		},
 	}
 	return apiFilm
 }
@@ -189,6 +194,31 @@ func TestFilmApiToModel(t *testing.T) {
 	assert.Equal(t, "An Award", model.AwardCategories[0].Title, "award_categories.title")
 }
 
+func TestFilmApiToModelImages(t *testing.T) {
+	itemIndex := make(models.ItemIndex)
+
+	serviceConfig := commonServiceConfig()
+
+	apiFilm := filmV2{
+		ID:    123,
+		Title: "Film 99",
+		Slug:  "/film/99",
+		ImageUrls: map[string]interface{}{
+			"background_image": "background.png",
+			"portrait":         "portrait.jpg",
+			"landscape_image":  nil,
+			"sponsor_image":    "sponsor.bmp",
+		},
+	}
+
+	model := apiFilm.mapToModel(serviceConfig, itemIndex)
+
+	assert.Equal(t, model.Images["Background"], "background.png", "should be equal")
+	assert.Equal(t, model.Images["Portrait"], "portrait.jpg", "should be equal")
+	assert.Nil(t, model.Images["Landscape"], "should be nil")
+	assert.Equal(t, model.Images["Sponsor"], "sponsor.bmp", "should be equal")
+}
+
 func TestFilmApiToModelWithoutClassifications(t *testing.T) {
 	itemIndex := make(models.ItemIndex)
 	serviceConfig := commonServiceConfig()
@@ -208,8 +238,7 @@ func TestFilmApiToModelWithoutSeoImage(t *testing.T) {
 
 	apiFilm := getFilm()
 	imageURL := "image.jpeg"
-	apiFilm.ImageUrls.Portrait = imageURL
-	apiFilm.ImageUrls.Landscape = imageURL
+	apiFilm.ImageUrls["seo_image"] = imageURL
 
 	model := apiFilm.mapToModel(serviceConfig, itemIndex)
 
@@ -224,7 +253,7 @@ func TestFilmApiToModelWithSeoImage(t *testing.T) {
 
 	apiFilm := getFilm()
 	imageURL := "seo_image.jpeg"
-	apiFilm.ImageUrls.Seo = imageURL
+	apiFilm.ImageUrls["seo_image"] = imageURL
 
 	model := apiFilm.mapToModel(serviceConfig, itemIndex)
 

--- a/kibble/api/films_test.go
+++ b/kibble/api/films_test.go
@@ -134,7 +134,7 @@ func getFilm() filmV2 {
 			DisplayLabel: "The Award 2021",
 			IsWinner:     true,
 		}},
-		ImageUrls: map[string]interface{}{},
+		ImageUrls: map[string]string{},
 	}
 	return apiFilm
 }
@@ -199,10 +199,10 @@ func TestFilmApiToModelImages(t *testing.T) {
 		ID:    123,
 		Title: "Film 99",
 		Slug:  "/film/99",
-		ImageUrls: map[string]interface{}{
+		ImageUrls: map[string]string{
 			"background_image": "background.png",
 			"portrait":         "portrait.jpg",
-			"landscape_image":  nil,
+			"landscape_image":  "",
 			"sponsor_image":    "sponsor.bmp",
 		},
 	}
@@ -215,7 +215,7 @@ func TestFilmApiToModelImages(t *testing.T) {
 
 	assert.Equal(t, model.ImageMap["Background"], "background.png", "should be equal")
 	assert.Equal(t, model.ImageMap["Portrait"], "portrait.jpg", "should be equal")
-	assert.Nil(t, model.ImageMap["Landscape"], "should be nil")
+	assert.Empty(t, model.ImageMap["Landscape"], "should be empty")
 	assert.Equal(t, model.ImageMap["Sponsor"], "sponsor.bmp", "should be equal")
 }
 

--- a/kibble/api/films_test.go
+++ b/kibble/api/films_test.go
@@ -209,10 +209,14 @@ func TestFilmApiToModelImages(t *testing.T) {
 
 	model := apiFilm.mapToModel(serviceConfig, itemIndex)
 
-	assert.Equal(t, model.Images["Background"], "background.png", "should be equal")
-	assert.Equal(t, model.Images["Portrait"], "portrait.jpg", "should be equal")
-	assert.Nil(t, model.Images["Landscape"], "should be nil")
-	assert.Equal(t, model.Images["Sponsor"], "sponsor.bmp", "should be equal")
+	assert.Equal(t, model.Images.Background, "background.png", "should be equal")
+	assert.Equal(t, model.Images.Portrait, "portrait.jpg", "should be equal")
+	assert.Empty(t, model.Images.Landscape, "should be empty")
+
+	assert.Equal(t, model.ImageMap["Background"], "background.png", "should be equal")
+	assert.Equal(t, model.ImageMap["Portrait"], "portrait.jpg", "should be equal")
+	assert.Nil(t, model.ImageMap["Landscape"], "should be nil")
+	assert.Equal(t, model.ImageMap["Sponsor"], "sponsor.bmp", "should be equal")
 }
 
 func TestFilmApiToModelWithoutClassifications(t *testing.T) {

--- a/kibble/models/film.go
+++ b/kibble/models/film.go
@@ -44,7 +44,7 @@ type Film struct {
 	AwardCategories []AwardCategory
 	Tags            StringCollection
 	Seo             Seo
-	Images          ImageSet
+	Images          ImageMap
 	Prices          PriceInfo
 	Available       Period
 	Recommendations []GenericItem
@@ -85,7 +85,7 @@ func (film Film) GetGenericItem() GenericItem {
 	return GenericItem{
 		Title:     film.Title,
 		Slug:      film.Slug,
-		Images:    film.Images,
+		Images:    ImageMapToImageSet(film.Images),
 		ItemType:  "film",
 		InnerItem: film,
 		StatusID:  film.StatusID,

--- a/kibble/models/film.go
+++ b/kibble/models/film.go
@@ -44,7 +44,8 @@ type Film struct {
 	AwardCategories []AwardCategory
 	Tags            StringCollection
 	Seo             Seo
-	Images          ImageMap
+	Images          ImageSet
+	ImageMap        ImageMap
 	Prices          PriceInfo
 	Available       Period
 	Recommendations []GenericItem
@@ -85,7 +86,7 @@ func (film Film) GetGenericItem() GenericItem {
 	return GenericItem{
 		Title:     film.Title,
 		Slug:      film.Slug,
-		Images:    ImageMapToImageSet(film.Images),
+		Images:    film.Images,
 		ItemType:  "film",
 		InnerItem: film,
 		StatusID:  film.StatusID,

--- a/kibble/models/site.go
+++ b/kibble/models/site.go
@@ -50,7 +50,7 @@ type ImageSet struct {
 }
 
 // All-purpose map between image type and path
-type ImageMap map[string]interface{}
+type ImageMap map[string]string
 
 // Seo - common seo settings
 type Seo struct {
@@ -185,39 +185,27 @@ func ImageMapToImageSet(imageMap ImageMap) ImageSet {
 	images := ImageSet{}
 
 	if path, ok := imageMap["Portrait"]; ok {
-		if path != nil {
-			images.Portrait = path.(string)
-		}
+		images.Portrait = path
 	}
 
 	if path, ok := imageMap["Landscape"]; ok {
-		if path != nil {
-			images.Landscape = path.(string)
-		}
+		images.Landscape = path
 	}
 
 	if path, ok := imageMap["Header"]; ok {
-		if path != nil {
-			images.Header = path.(string)
-		}
+		images.Header = path
 	}
 
 	if path, ok := imageMap["Background"]; ok {
-		if path != nil {
-			images.Background = path.(string)
-		}
+		images.Background = path
 	}
 
 	if path, ok := imageMap["Carousel"]; ok {
-		if path != nil {
-			images.Carousel = path.(string)
-		}
+		images.Carousel = path
 	}
 
 	if path, ok := imageMap["Classification"]; ok {
-		if path != nil {
-			images.Classification = path.(string)
-		}
+		images.Classification = path
 	}
 
 	return images

--- a/kibble/models/site.go
+++ b/kibble/models/site.go
@@ -49,6 +49,9 @@ type ImageSet struct {
 	Seo            string
 }
 
+// All-purpose map between image type and path
+type ImageMap map[string]interface{}
+
 // Seo - common seo settings
 type Seo struct {
 	SiteName    string
@@ -92,7 +95,7 @@ type CastMember struct {
 type AwardCategory struct {
 	Title        string
 	DisplayLabel string
-	IsWinner       bool
+	IsWinner     bool
 }
 
 // SubtitleTrack -
@@ -174,4 +177,48 @@ func (site *Site) LanguagesToLanguageConfigs() map[string]LanguageConfig {
 	}
 
 	return configMap
+}
+
+// Convert an ImageMap to an ImageSet of hard-coded image names (which we will eventually phase out)
+func ImageMapToImageSet(imageMap ImageMap) ImageSet {
+
+	images := ImageSet{}
+
+	if path, ok := imageMap["Portrait"]; ok {
+		if path != nil {
+			images.Portrait = path.(string)
+		}
+	}
+
+	if path, ok := imageMap["Landscape"]; ok {
+		if path != nil {
+			images.Landscape = path.(string)
+		}
+	}
+
+	if path, ok := imageMap["Header"]; ok {
+		if path != nil {
+			images.Header = path.(string)
+		}
+	}
+
+	if path, ok := imageMap["Background"]; ok {
+		if path != nil {
+			images.Background = path.(string)
+		}
+	}
+
+	if path, ok := imageMap["Carousel"]; ok {
+		if path != nil {
+			images.Carousel = path.(string)
+		}
+	}
+
+	if path, ok := imageMap["Classification"]; ok {
+		if path != nil {
+			images.Classification = path.(string)
+		}
+	}
+
+	return images
 }


### PR DESCRIPTION
- in the near future, the number and name of film images won't be as strictly defined as we're used to
- potentially any number of images will be available in the API to support client requirements (e.g. 'logo_image', 'sponsor_image')
- currently Kibble uses a struct to hold these images but this needs to move to something more accommodating and flexible
- the API package now stores `ImageUrls` as a `map[string]interface{}`, a change also reflected in the `Film` model attribute `Images`
- when translating a Film object to a GenericItem, this ImageMap is converted to an ImageSet with the already-established limited set of hard-coded image types
- this should do the trick in a template rendering context, as the `film/item.jet` template uses the Film object, not the derived GenericItem (and the InnerItem is always available to query)
- the only template changes required are 3 instances of film.Images.Foo in `film/item.jet` - need to change to film.Images["Foo"]