### PR TITLE
Fix: Make linter happy

### DIFF
--- a/kibble/api/cache.go
+++ b/kibble/api/cache.go
@@ -45,7 +45,7 @@ var cache = httpcache.Cache(httpcache.NewMemoryCache())
 // CheckAdminCredentials - check that the admin credentials are valid
 func CheckAdminCredentials(cfg *models.Config) {
 
-	if cfg.RunAsAdmin && cfg.SkipLogin == false {
+	if cfg.RunAsAdmin && !cfg.SkipLogin {
 		isAdmin, err := IsAdmin(cfg)
 		if err != nil {
 			fmt.Println(err)
@@ -213,6 +213,9 @@ func newfileUploadRequest(uri string, params map[string]string, paramName, path 
 		return nil, err
 	}
 	count, err := io.Copy(part, file)
+	if err != nil {
+		return nil, err
+	}
 	log.Debugf("uploading bytes %d", count)
 
 	for key, val := range params {

--- a/kibble/api/languages_test.go
+++ b/kibble/api/languages_test.go
@@ -47,7 +47,9 @@ func TestLoadAllLanguagesFromConfig(t *testing.T) {
 	}
 
 	site := &models.Site{}
-	loadAllLanguagesFromConfig(cfg, site)
+	if err := loadAllLanguagesFromConfig(cfg, site); err != nil {
+		t.Error(err)
+	}
 	assert.Equal(t, site.Languages, []models.Language{
 		{Code: "de", Name: "Deutsche", Label: "", Locale: "", DefinitionFilePath: "", IsDefault: false},
 		{Code: "", Name: "English", Label: "", Locale: "", DefinitionFilePath: "", IsDefault: true},

--- a/kibble/api/site.go
+++ b/kibble/api/site.go
@@ -104,14 +104,14 @@ func LoadSite(cfg *models.Config) (*models.Site, error) {
 	// while there are unresolved film slugs
 	s := itemIndex.FindUnresolvedSlugs("film")
 	for len(s) > 0 {
-		AppendFilms(cfg, site, s, itemIndex)
+		_ = AppendFilms(cfg, site, s, itemIndex)
 		s = itemIndex.FindUnresolvedSlugs("film")
 	}
 
 	// while there are unresolved tv season slugs
 	tvs := itemIndex.FindUnresolvedSlugs("tv-season")
 	for len(tvs) > 0 {
-		AppendTVSeasons(cfg, site, tvs, itemIndex)
+		_ = AppendTVSeasons(cfg, site, tvs, itemIndex)
 		tvs = itemIndex.FindUnresolvedSlugs("tv-season")
 	}
 

--- a/kibble/api/tv_test.go
+++ b/kibble/api/tv_test.go
@@ -31,7 +31,9 @@ func TestLoadAll(t *testing.T) {
 	itemIndex := make(models.ItemIndex)
 	site := &models.Site{}
 
-	AppendAllTVShows(cfg, site, itemIndex)
+	if err := AppendAllTVShows(cfg, site, itemIndex); err != nil {
+		t.Error(err)
+	}
 
 }
 

--- a/kibble/cmd/render.go
+++ b/kibble/cmd/render.go
@@ -18,6 +18,7 @@ import (
 	"kibble/config"
 	"kibble/render"
 	"kibble/utils"
+
 	"github.com/spf13/cobra"
 )
 
@@ -37,12 +38,12 @@ Kibble is used to build and develop custom sites to run on the SHIFT72 platform.
 		if watch || serve {
 			log := utils.ConfigureWatchedLogging(utils.ConvertToLoggingLevel(verbose))
 			cfg := config.LoadConfig(runAsAdmin, apiKey, disableCache)
-			config.CheckVersion(cfg)
+			_ = config.CheckVersion(cfg)
 			render.Watch(cfg.SourcePath(), cfg.BuildPath(), cfg, port, log, watch)
 		} else {
 			utils.ConfigureStandardLogging(utils.ConvertToLoggingLevel(verbose))
 			cfg := config.LoadConfig(runAsAdmin, apiKey, disableCache)
-			config.CheckVersion(cfg)
+			_ = config.CheckVersion(cfg)
 			render.Render(cfg.SourcePath(), cfg.BuildPath(), cfg)
 		}
 	},

--- a/kibble/cmd/root.go
+++ b/kibble/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cfgFile string
 var runAsAdmin bool
 var disableCache bool
 var verbose bool

--- a/kibble/cmd/sync.go
+++ b/kibble/cmd/sync.go
@@ -24,6 +24,7 @@ import (
 	"kibble/render"
 	"kibble/sync"
 	"kibble/utils"
+
 	logging "github.com/op/go-logging"
 	"github.com/spf13/cobra"
 )
@@ -51,7 +52,7 @@ var syncCmd = &cobra.Command{
 		}
 
 		cfg := config.LoadConfig(runAsAdmin, apiKey, disableCache)
-		config.CheckVersion(cfg)
+		_ = config.CheckVersion(cfg)
 
 		if syncCfg.SiteURL != "" {
 			cfg.SiteURL = syncCfg.SiteURL

--- a/kibble/models/template.go
+++ b/kibble/models/template.go
@@ -255,14 +255,14 @@ func ConfigureShortcodeTemplatePath(cfg *Config) {
 		// built-in templates
 		_, err := shortCodeView.LoadTemplate("echo.jet", "<div class=\"echo\">slug:{{slug}}</div>")
 		if err != nil {
-			log.Error("loading failed for template echo.jet")
+			log.Error("template loading failed for echo.jet")
 		}
 		_, err = shortCodeView.LoadTemplate("youtube.jet", `
 <div {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; overflow: hidden;\"" | raw }} >
 <iframe src="//www.youtube.com/embed/{{id}}" {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%;\"" | raw }}{{if isset(autoplay) && autoplay=="true" }} autoplay=1{{end}} allowfullscreen frameborder="0"></iframe>
 </div>`)
 		if err != nil {
-			log.Error("loading failed for template youtube.jet")
+			log.Error("template loading failed for youtube.jet")
 		}
 	}
 }

--- a/kibble/models/template.go
+++ b/kibble/models/template.go
@@ -253,17 +253,27 @@ func ConfigureShortcodeTemplatePath(cfg *Config) {
 		shortCodeView = jet.NewHTMLSet(cfg.ShortCodePath())
 
 		// built-in templates
-		shortCodeView.LoadTemplate("echo.jet", "<div class=\"echo\">slug:{{slug}}</div>")
-		shortCodeView.LoadTemplate("youtube.jet", `
+		_, err := shortCodeView.LoadTemplate("echo.jet", "<div class=\"echo\">slug:{{slug}}</div>")
+		if err != nil {
+			log.Error("loading failed for template echo.jet")
+		}
+		_, err = shortCodeView.LoadTemplate("youtube.jet", `
 <div {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; overflow: hidden;\"" | raw }} >
 <iframe src="//www.youtube.com/embed/{{id}}" {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%;\"" | raw }}{{if isset(autoplay) && autoplay=="true" }} autoplay=1{{end}} allowfullscreen frameborder="0"></iframe>
 </div>`)
+		if err != nil {
+			log.Error("loading failed for template youtube.jet")
+		}
 	}
 }
 
 func processTemplateTag(templateTag string) string {
 
 	templateName, data, err := parseParameters(templateTag)
+	if err != nil {
+		log.Error("Parsing parameters from template tag faild: %v", err)
+		return "Err"
+	}
 
 	w := bytes.NewBufferString("")
 	templatePath := fmt.Sprintf("%s.jet", templateName)
@@ -280,7 +290,7 @@ func processTemplateTag(templateTag string) string {
 		log.Errorf("Shortcode template execute error: %s", err)
 	}
 
-	return string(w.Bytes())
+	return w.String()
 }
 
 // parse the template tag into the template and arguments

--- a/kibble/render/file_renderer.go
+++ b/kibble/render/file_renderer.go
@@ -46,6 +46,9 @@ func (c FileRenderer) Initialise() {
 	// copy language files too, they are a special file name format
 	glob := filepath.Join(c.sourcePath, "/*.all.json")
 	langFiles, err := filepath.Glob(glob)
+	if err != nil {
+		log.Warningf("Warn: getting language files failed %s", err)
+	}
 	if len(langFiles) > 0 {
 		for _, file := range langFiles {
 			dst := filepath.Join(c.buildPath, filepath.Base(file))
@@ -93,7 +96,9 @@ func (c FileRenderer) Render(templatePath string, filePath string, data jet.VarM
 	}
 
 	dirPath := filepath.Dir(fullPath)
-	os.MkdirAll(dirPath, 0777)
+	if err := os.MkdirAll(dirPath, 0777); err != nil {
+		log.Warningf("Error while creating directory: %s: %s", dirPath, err)
+	}
 
 	// optional check
 	if _, err := os.Stat(fullPath); err == nil {

--- a/kibble/sync/local_store.go
+++ b/kibble/sync/local_store.go
@@ -48,7 +48,11 @@ func (store *LocalStore) List() (FileRefCollection, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.Chdir(wd)
+	defer func() {
+		if err := os.Chdir(wd); err != nil {
+			log.Errorf("WARN: error while changing directory back to original %s", err)
+		}
+	}()
 
 	var fileList []FileRef
 	err = filepath.Walk(".", func(path string, f os.FileInfo, err error) error {

--- a/kibble/sync/sync_test.go
+++ b/kibble/sync/sync_test.go
@@ -207,7 +207,10 @@ func TestSync(t *testing.T) {
 		local = append(local, add(fmt.Sprintf("file%d.html|ccc", i)))
 	}
 
-	PerformSync(store, local, remote)
+	_, _, err := PerformSync(store, local, remote)
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func TestSyncWithErrors(t *testing.T) {
@@ -231,11 +234,5 @@ func TestSyncWithErrors(t *testing.T) {
 func add(raw string) (f FileRef) {
 	f = parseFileRef(raw)
 	f.action = ADD
-	return
-}
-
-func remove(raw string) (f FileRef) {
-	f = parseFileRef(raw)
-	f.action = REMOVE
 	return
 }

--- a/kibble/test/inmemory_renderer.go
+++ b/kibble/test/inmemory_renderer.go
@@ -38,7 +38,7 @@ type InMemoryResult struct {
 // Output - return the result
 func (r *InMemoryResult) Output() string {
 	if r.err == nil {
-		return fmt.Sprintf("%s", r.buffer)
+		return r.buffer.String()
 	}
 	return fmt.Sprintf("error: %s\n", r.err)
 }
@@ -67,7 +67,7 @@ func (c *InMemoryRenderer) DumpErrors(t *testing.T) {
 func (c *InMemoryRenderer) DumpResults() {
 	for _, r := range c.Results {
 		fmt.Printf("---- %s start ----\n", r.filePath)
-		fmt.Printf(r.Output())
+		fmt.Println(r.Output())
 		fmt.Printf("---- %s end ----\n", r.filePath)
 	}
 }

--- a/kibble/utils/perf.go
+++ b/kibble/utils/perf.go
@@ -45,7 +45,7 @@ func NewStopwatchf(msg string, a ...interface{}) *Stopwatch {
 
 // Completed - stops the stop watch
 func (sw *Stopwatch) Completed() time.Duration {
-	d := round(time.Now().Sub(sw.start), time.Millisecond)
+	d := round(time.Since(sw.start), time.Millisecond)
 	if log.IsEnabledFor(sw.level) {
 		log.Noticef("%s: %s", sw.msg, d)
 	} else {


### PR DESCRIPTION
It would be nice to use any linter on GitHub Action. This will be the first step towards that.
eg: [golangci-lint](https://golangci-lint.run/)

* check returned errors
* use time.Since instead of time.Now().Sub
* should use String() instead of fmt.Sprintf
* use w.String() instead of string(w.Bytes())
* handle error from parseParameters
* remove unused cfgFile
* ineffectual assignment to err
* should omit comparison to bool constant, can be simplified to \!cfg.SkipLogin
* remove unused ignorePath and ignorePaths
* remove unsed remove function from sync_test.go