### PR TITLE
Fix/test country code order

### DIFF
--- a/kibble/api/tv_test.go
+++ b/kibble/api/tv_test.go
@@ -242,8 +242,9 @@ func TestSeasonClassifications(t *testing.T) {
 
 	assert.Equal(t, 2, len(model.Classifications))
 
-	assert.Equal(t, "au", model.Classifications[0].CountryCode)
-	assert.Equal(t, "nz", model.Classifications[1].CountryCode)
+	countryCodes := [2]string{model.Classifications[0].CountryCode, model.Classifications[1].CountryCode}
+	assert.Contains(t, countryCodes, "au", "expect 'au' in country codes")
+	assert.Contains(t, countryCodes, "nz", "expect 'nz' in country codes")
 }
 
 func TestSeasonWithoutClassifications(t *testing.T) {

--- a/kibble/api/tv_test.go
+++ b/kibble/api/tv_test.go
@@ -240,11 +240,20 @@ func TestSeasonClassifications(t *testing.T) {
 
 	model := apiSeason.mapToModel(serviceConfig, itemIndex)
 
-	assert.Equal(t, 2, len(model.Classifications))
-
-	countryCodes := [2]string{model.Classifications[0].CountryCode, model.Classifications[1].CountryCode}
-	assert.Contains(t, countryCodes, "au", "expect 'au' in country codes")
-	assert.Contains(t, countryCodes, "nz", "expect 'nz' in country codes")
+	// Check these are the members of the list, regardless of order
+	expect := []models.Classification{
+		{
+			CountryCode: "au",
+			Label:       "Australian Label",
+			Description: "Australian Description",
+		},
+		{
+			CountryCode: "nz",
+			Label:       "NZ Label",
+			Description: "NZ Description",
+		},
+	}
+	assert.ElementsMatch(t, model.Classifications, expect)
 }
 
 func TestSeasonWithoutClassifications(t *testing.T) {


### PR DESCRIPTION
Sometimes this test fails because the order of the Classifications can't be guaranteed