### PR TITLE
Ab#6711 upgrade cloudykit/jet to 6.1.0

### DIFF
--- a/kibble/datastore/bundle_datasource.go
+++ b/kibble/datastore/bundle_datasource.go
@@ -23,7 +23,7 @@ import (
 	"kibble/models"
 	"kibble/utils"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 var bundleArgs = []models.RouteArgument{

--- a/kibble/datastore/bundle_index_datasource.go
+++ b/kibble/datastore/bundle_index_datasource.go
@@ -17,8 +17,9 @@ package datastore
 import (
 	"reflect"
 
-	"github.com/CloudyKit/jet"
 	"kibble/models"
+
+	"github.com/CloudyKit/jet/v6"
 )
 
 // BundleIndexDataSource - a list of all bundles

--- a/kibble/datastore/collection_datasource.go
+++ b/kibble/datastore/collection_datasource.go
@@ -23,7 +23,7 @@ import (
 	"kibble/models"
 	"kibble/utils"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 var collectionArgs = []models.RouteArgument{

--- a/kibble/datastore/collection_index_datasource.go
+++ b/kibble/datastore/collection_index_datasource.go
@@ -17,8 +17,9 @@ package datastore
 import (
 	"reflect"
 
-	"github.com/CloudyKit/jet"
 	"kibble/models"
+
+	"github.com/CloudyKit/jet/v6"
 )
 
 // CollectionIndexDataSource - a list of all Collections

--- a/kibble/datastore/file_system_datasource.go
+++ b/kibble/datastore/file_system_datasource.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 var fileSystemArgs = []models.RouteArgument{}

--- a/kibble/datastore/film_datasource.go
+++ b/kibble/datastore/film_datasource.go
@@ -22,7 +22,7 @@ import (
 
 	"kibble/models"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 var filmArgs = []models.RouteArgument{

--- a/kibble/datastore/film_index_datasource.go
+++ b/kibble/datastore/film_index_datasource.go
@@ -18,7 +18,7 @@ import (
 	"kibble/models"
 	"reflect"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 
 	logging "github.com/op/go-logging"
 )

--- a/kibble/datastore/films_test.go
+++ b/kibble/datastore/films_test.go
@@ -20,7 +20,8 @@ import (
 
 	"kibble/models"
 	"kibble/test"
-	"github.com/CloudyKit/jet"
+
+	"github.com/CloudyKit/jet/v6"
 	"github.com/nicksnyder/go-i18n/i18n"
 	"github.com/stretchr/testify/assert"
 )
@@ -105,10 +106,13 @@ func TestFilmDataStore(t *testing.T) {
 
 func TestRenderingGlobal(t *testing.T) {
 
-	view := jet.NewHTMLSet("../templates/")
-	view.AddGlobal("version", "v1.1.145")
+	loader := jet.NewInMemLoader()
+	loader.Set("version.jet", "{{ version }}")
 
-	tem, _ := view.LoadTemplate("", "{{ version }}")
+	view := jet.NewSet(loader)
+	view.AddGlobal("version", "v1.1.146")
+
+	tem, _ := view.GetTemplate("version.jet")
 
 	renderer1 := &test.InMemoryTemplateRenderer{
 		View:     view,
@@ -138,7 +142,7 @@ func TestRenderingGlobal(t *testing.T) {
 	var fds FilmDataSource
 	fds.Iterator(ctx, renderer1)
 
-	if renderer1.Result.Output() != "v1.1.145" {
+	if renderer1.Result.Output() != "v1.1.146" {
 		t.Error("Unexpected output")
 	}
 }
@@ -176,8 +180,7 @@ func TestRenderingSlug(t *testing.T) {
 	assert.NoError(t, err)
 
 	view := models.CreateTemplateView(routeRegistry, i18n.IdentityTfunc(), &ctx, "./templates")
-
-	tem, _ := view.LoadTemplate("", "{{ routeToSlug(film.Slug, \"filmItem\") }}")
+	tem, err := view.GetTemplate("film_slug.jet")
 
 	renderer := &test.InMemoryTemplateRenderer{
 		View:     view,
@@ -226,7 +229,7 @@ func TestRouteToFilm(t *testing.T) {
 
 	view := models.CreateTemplateView(routeRegistry, i18n.IdentityTfunc(), &ctx, "./templates")
 
-	tem, _ := view.LoadTemplate("", "{{ routeTo(film, \"filmItem\") }}")
+	tem, _ := view.GetTemplate("film_route.jet")
 
 	renderer := &test.InMemoryTemplateRenderer{
 		View:     view,
@@ -274,7 +277,7 @@ func TestTransLanguage(t *testing.T) {
 
 	view := models.CreateTemplateView(routeRegistry, i18n.IdentityTfunc(), &ctx, "./templates")
 
-	tem, _ := view.LoadTemplate("", "MSG {{ i18n(\"settings_title\") }}")
+	tem, _ := view.GetTemplate("film_translation.jet")
 
 	renderer := &test.InMemoryTemplateRenderer{
 		View:     view,

--- a/kibble/datastore/page_datasource.go
+++ b/kibble/datastore/page_datasource.go
@@ -23,7 +23,7 @@ import (
 	"kibble/models"
 	"kibble/utils"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 var pageArgs = []models.RouteArgument{

--- a/kibble/datastore/page_index_datasource.go
+++ b/kibble/datastore/page_index_datasource.go
@@ -22,7 +22,7 @@ import (
 
 	"kibble/models"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 var indexArgs = []models.RouteArgument{

--- a/kibble/datastore/site_test.go
+++ b/kibble/datastore/site_test.go
@@ -6,9 +6,10 @@ import (
 	"github.com/nicksnyder/go-i18n/i18n"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/CloudyKit/jet"
 	"kibble/models"
 	"kibble/test"
+
+	"github.com/CloudyKit/jet/v6"
 )
 
 func TestSitePlans(t *testing.T) {

--- a/kibble/datastore/templates/echo.jet
+++ b/kibble/datastore/templates/echo.jet
@@ -1,0 +1,1 @@
+<div class="echo">slug:{{slug}}</div>

--- a/kibble/datastore/templates/film_route.jet
+++ b/kibble/datastore/templates/film_route.jet
@@ -1,0 +1,1 @@
+{{ routeTo(film, "filmItem") }}

--- a/kibble/datastore/templates/film_slug.jet
+++ b/kibble/datastore/templates/film_slug.jet
@@ -1,0 +1,1 @@
+{{ routeToSlug(film.Slug) }}

--- a/kibble/datastore/templates/film_translation.jet
+++ b/kibble/datastore/templates/film_translation.jet
@@ -1,0 +1,1 @@
+MSG {{ i18n("settings_title") }}

--- a/kibble/datastore/templates/tv_show_slug.jet
+++ b/kibble/datastore/templates/tv_show_slug.jet
@@ -1,0 +1,1 @@
+{{ routeToSlug(site.TVShows[0].Slug) }}

--- a/kibble/datastore/templates/youtube.jet
+++ b/kibble/datastore/templates/youtube.jet
@@ -1,0 +1,3 @@
+<div {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; overflow: hidden;\"" | raw }} >
+<iframe src="//www.youtube.com/embed/{{id}}" {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%;\"" | raw }}{{if isset(autoplay) && autoplay=="true" }} autoplay=1{{end}} allowfullscreen frameborder="0"></iframe>
+</div>

--- a/kibble/datastore/tv_episode_datasource.go
+++ b/kibble/datastore/tv_episode_datasource.go
@@ -22,7 +22,7 @@ import (
 
 	"kibble/models"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 var tvEpisodeArgs = []models.RouteArgument{

--- a/kibble/datastore/tv_season_datasource.go
+++ b/kibble/datastore/tv_season_datasource.go
@@ -22,7 +22,7 @@ import (
 
 	"kibble/models"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 var tvSeasonArgs = []models.RouteArgument{

--- a/kibble/datastore/tv_season_index_datasource.go
+++ b/kibble/datastore/tv_season_index_datasource.go
@@ -19,7 +19,7 @@ import (
 
 	"kibble/models"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 // TVSeasonIndexDataSource - a list of all films

--- a/kibble/datastore/tv_show_datasource.go
+++ b/kibble/datastore/tv_show_datasource.go
@@ -22,7 +22,7 @@ import (
 
 	"kibble/models"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 var tvShowArgs = []models.RouteArgument{

--- a/kibble/datastore/tv_show_index_datasource.go
+++ b/kibble/datastore/tv_show_index_datasource.go
@@ -19,7 +19,7 @@ import (
 
 	"kibble/models"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 // TVShowIndexDataSource - a list of all films

--- a/kibble/datastore/tv_show_test.go
+++ b/kibble/datastore/tv_show_test.go
@@ -15,10 +15,9 @@
 package datastore
 
 import (
-	"testing"
-
 	"kibble/models"
 	"kibble/test"
+	"testing"
 
 	"github.com/nicksnyder/go-i18n/i18n"
 	"github.com/stretchr/testify/assert"
@@ -58,7 +57,7 @@ func TestRenderingShowSlug(t *testing.T) {
 
 	view := models.CreateTemplateView(routeRegistry, i18n.IdentityTfunc(), &ctx, "./templates")
 
-	tem, _ := view.LoadTemplate("", "{{ routeToSlug(site.TVShows[0].Slug) }}")
+	tem, _ := view.GetTemplate("tv_show_slug.jet")
 
 	renderer := &test.InMemoryTemplateRenderer{
 		View:     view,

--- a/kibble/go.mod
+++ b/kibble/go.mod
@@ -3,7 +3,7 @@ module kibble
 go 1.17
 
 require (
-	github.com/CloudyKit/jet v2.1.1+incompatible
+	github.com/CloudyKit/jet/v6 v6.1.0
 	github.com/araddon/dateparse v0.0.0-20210207001429-0eec95c9db7e
 	github.com/aws/aws-sdk-go v1.12.2
 	github.com/gosimple/slug v1.1.1
@@ -24,7 +24,7 @@ require (
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a // indirect
+	github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53 // indirect
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-ini/ini v1.28.2 // indirect

--- a/kibble/go.sum
+++ b/kibble/go.sum
@@ -1,9 +1,9 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a h1:3SgJcK9l5uPdBC/X17wanyJAMxM33+4ZhEIV96MIH8U=
-github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
-github.com/CloudyKit/jet v2.1.1+incompatible h1:FgCzTmQg2GEqM3Xo3pvMYmJdYjqycdapGxRoyJ68O1c=
-github.com/CloudyKit/jet v2.1.1+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
+github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53 h1:sR+/8Yb4slttB4vD+b9btVEnWgL3Q00OBTzVT8B9C0c=
+github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
+github.com/CloudyKit/jet/v6 v6.1.0 h1:hvO96X345XagdH1fAoBjpBYG4a1ghhL/QzalkduPuXk=
+github.com/CloudyKit/jet/v6 v6.1.0/go.mod h1:d3ypHeIRNo2+XyqnGA8s+aphtcVpjP5hPwP/Lzo7Ro4=
 github.com/araddon/dateparse v0.0.0-20210207001429-0eec95c9db7e h1:OjdSMCht0ZVX7IH0nTdf00xEustvbtUGRgMh3gbdmOg=
 github.com/araddon/dateparse v0.0.0-20210207001429-0eec95c9db7e/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/aws/aws-sdk-go v1.12.2 h1:wY/ELcBLPYpPgFtzSLzfvk06ERAyyfJ7xp1h56VKXAk=

--- a/kibble/models/render.go
+++ b/kibble/models/render.go
@@ -15,7 +15,7 @@
 package models
 
 import (
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 // RenderContext - Context passed during rendering / serving

--- a/kibble/models/template.go
+++ b/kibble/models/template.go
@@ -24,7 +24,7 @@ import (
 
 	"kibble/version"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 	strip "github.com/grokify/html-strip-tags-go"
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/nicksnyder/go-i18n/i18n"
@@ -37,7 +37,10 @@ var shortCodeView *jet.Set
 // CreateTemplateView - create a template view
 func CreateTemplateView(routeRegistry *RouteRegistry, trans i18n.TranslateFunc, ctx *RenderContext, templatePath string) *jet.Set {
 
-	view := jet.NewHTMLSet(templatePath)
+	// loader := jet.NewInMemLoader()
+	fmt.Println("TEMPLATE PATH>>", templatePath)
+	view := jet.NewSet(jet.NewOSFileSystemLoader(templatePath))
+	// view := jet.NewHTMLSet(templatePath)
 	view.AddGlobal("version", version.Version)
 	view.AddGlobal("lang", ctx.Language)
 	view.AddGlobal("routeTo", func(entity interface{}, routeName string) string {
@@ -250,20 +253,8 @@ func ConfigureShortcodeTemplatePath(cfg *Config) {
 
 	if shortCodeView == nil {
 		// get the template view
-		shortCodeView = jet.NewHTMLSet(cfg.ShortCodePath())
-
-		// built-in templates
-		_, err := shortCodeView.LoadTemplate("echo.jet", "<div class=\"echo\">slug:{{slug}}</div>")
-		if err != nil {
-			log.Error("template loading failed for echo.jet")
-		}
-		_, err = shortCodeView.LoadTemplate("youtube.jet", `
-<div {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; overflow: hidden;\"" | raw }} >
-<iframe src="//www.youtube.com/embed/{{id}}" {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%;\"" | raw }}{{if isset(autoplay) && autoplay=="true" }} autoplay=1{{end}} allowfullscreen frameborder="0"></iframe>
-</div>`)
-		if err != nil {
-			log.Error("template loading failed for youtube.jet")
-		}
+		loader := jet.NewOSFileSystemLoader(cfg.ShortCodePath())
+		shortCodeView = jet.NewSet(loader)
 	}
 }
 

--- a/kibble/models/template.go
+++ b/kibble/models/template.go
@@ -37,10 +37,7 @@ var shortCodeView *jet.Set
 // CreateTemplateView - create a template view
 func CreateTemplateView(routeRegistry *RouteRegistry, trans i18n.TranslateFunc, ctx *RenderContext, templatePath string) *jet.Set {
 
-	// loader := jet.NewInMemLoader()
-	fmt.Println("TEMPLATE PATH>>", templatePath)
 	view := jet.NewSet(jet.NewOSFileSystemLoader(templatePath))
-	// view := jet.NewHTMLSet(templatePath)
 	view.AddGlobal("version", version.Version)
 	view.AddGlobal("lang", ctx.Language)
 	view.AddGlobal("routeTo", func(entity interface{}, routeName string) string {

--- a/kibble/models/template_test.go
+++ b/kibble/models/template_test.go
@@ -21,7 +21,7 @@ import (
 
 	"kibble/utils"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 	"github.com/nicksnyder/go-i18n/i18n"
 	"github.com/stretchr/testify/assert"
 )

--- a/kibble/render/console_renderer.go
+++ b/kibble/render/console_renderer.go
@@ -18,8 +18,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/CloudyKit/jet"
 	"kibble/models"
+
+	"github.com/CloudyKit/jet/v6"
 )
 
 // ConsoleRenderer - designed to render to the console for testing

--- a/kibble/render/file_renderer.go
+++ b/kibble/render/file_renderer.go
@@ -24,7 +24,7 @@ import (
 
 	"kibble/utils"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 // FileRenderer - designed to render to the file system for testing

--- a/kibble/sample_site/templates/shortcodes/echo.jet
+++ b/kibble/sample_site/templates/shortcodes/echo.jet
@@ -1,0 +1,1 @@
+<div class="echo">slug:{{slug}}</div>

--- a/kibble/sample_site/templates/shortcodes/youtube.jet
+++ b/kibble/sample_site/templates/shortcodes/youtube.jet
@@ -1,0 +1,4 @@
+
+<div {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: relative; padding-bottom: 56.25%; padding-top: 30px; height: 0; overflow: hidden;\"" | raw }} >
+<iframe src="//www.youtube.com/embed/{{id}}" {{isset(class) ? "class=\"" + class + "\"" : "style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%;\"" | raw }}{{if isset(autoplay) && autoplay=="true" }} autoplay=1{{end}} allowfullscreen frameborder="0"></iframe>
+</div>

--- a/kibble/test/inmemory_renderer.go
+++ b/kibble/test/inmemory_renderer.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 // InMemoryRenderer - render to memory for testing

--- a/kibble/test/inmemory_template_renderer.go
+++ b/kibble/test/inmemory_template_renderer.go
@@ -17,7 +17,7 @@ package test
 import (
 	"bytes"
 
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 // InMemoryTemplateRenderer - render template in memory

--- a/kibble/test/mock_renderer.go
+++ b/kibble/test/mock_renderer.go
@@ -15,7 +15,7 @@
 package test
 
 import (
-	"github.com/CloudyKit/jet"
+	"github.com/CloudyKit/jet/v6"
 )
 
 // MockRenderer - testable renderer


### PR DESCRIPTION
This is more of a proof of concept than anything else but given jet 2.1.1 is coming up 5 years old and there are some features we might like to take advantage of in later versions (some improvements to trim whitespace for example) I thought I'd see what would be involved in a/ making the tests run and b/  getting templates (specifically Curzon) to render.

a/ is definitely easier than b/ - the main difficulty is that templates are slurped in using NewSet(<file loader>) which can't be altered afterwards to insert strings masquerading as templates for testing, so the strings which were used as templates previously have been exported as files and are read in as part of this process.

Getting the templates to play ball is a harder proposition. It tends to be very unforgiving. You can see the changes required to get it working here https://github.com/indiereign/shift72-curzon/compare/master..e6ef680b2af7362bc7c2a87d810fca57c66c21d3. The main gotchas are 
 - ranges return the index first so anything which refers to `range item := items` will be an array of indices without any items
 - relative paths to templates need to be exact
 - you'd better instantiate every variable with `:=` otherwise that's a paddlin'

I know these are probably best practice anyway but it's quite confronting to see a wall of red error text on render. 

I don't know whether the fact that all sites use the latest builder version by design or accident but if there was a reason to ensure sites are build with specific versions rather than whatever the latest one is, updating jet to this version might be it.

Jibin is looking into whether we can benchmark Kibble performance as a whole rather than individual packages and I wonder if we'll see many improvements with an update to jet.