### PR TITLE
disable CGO

### DIFF
--- a/kibble/.goreleaser.yml
+++ b/kibble/.goreleaser.yml
@@ -1,4 +1,6 @@
 builds:
+  - env:
+      - CGO_ENABLED=0
   - binary: kibble
     goos:
       - windows

--- a/kibble/Makefile
+++ b/kibble/Makefile
@@ -7,6 +7,8 @@ GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
 BINARY=kibble
 
+export CGO_ENABLED=0
+
 GOARCH = amd64
 VERSION=$(shell git describe --abbrev=0 --tags)
 


### PR DESCRIPTION
Disable CGO. This allows running kibble on operating systems that have a different C runtime like apline