### PR TITLE
Fix: remove deprecated strings.Title

### DIFF
--- a/kibble/api/films.go
+++ b/kibble/api/films.go
@@ -24,6 +24,9 @@ import (
 
 	"kibble/models"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/gosimple/slug"
 )
 
@@ -124,7 +127,7 @@ func (f filmV2) mapToModel(serviceConfig models.ServiceConfig, itemIndex models.
 			key = "background"
 		}
 
-		titleCaseKey := strings.Title(strings.ToLower(key))
+		titleCaseKey := cases.Title(language.Und).String(key)
 		titleCaseKey = strings.Replace(titleCaseKey, "_image", "", -1)
 
 		if titleCaseKey != key {

--- a/kibble/api/films_test.go
+++ b/kibble/api/films_test.go
@@ -442,3 +442,26 @@ func TestFilmCrewJobs(t *testing.T) {
 	caterers := film.Crew.GetMembers("Caterer")
 	assert.Equal(t, 0, len(caterers))
 }
+func TestMapToModelWithImageURLs(t *testing.T) {
+	itemIndex := make(models.ItemIndex)
+	serviceConfig := commonServiceConfig()
+
+	tests := map[string]struct {
+		name   string
+		input  map[string]string
+		except models.ImageMap
+	}{
+		"with empty image urls":           {input: make(map[string]string), except: make(models.ImageMap)},
+		"with image urls":                 {input: map[string]string{"Logo_image": "img_url"}, except: models.ImageMap{"Logo": "img_url"}},
+		"with image urls in capital case": {input: map[string]string{"LOGO_IMAGE": "img_url"}, except: models.ImageMap{"Logo": "img_url"}},
+		"with image urls in lower case":   {input: map[string]string{"logo_image": "img_url"}, except: models.ImageMap{"Logo": "img_url"}},
+	}
+	filmV2 := filmV2{}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			filmV2.ImageUrls = tc.input
+			film := filmV2.mapToModel(serviceConfig, itemIndex)
+			assert.Equal(t, film.ImageMap, tc.except, name)
+		})
+	}
+}


### PR DESCRIPTION
strings.Title is deprecated in go 1.8.
https://pkg.go.dev/strings@master#Title

Credit goes to DR. Copied from his PR.