### PR TITLE
AB#7964: Add a function to get item count stats.

### DIFF
--- a/kibble/models/generic_item.go
+++ b/kibble/models/generic_item.go
@@ -59,3 +59,20 @@ func (i GenericItem) GetTranslatedTitle(T i18n.TranslateFunc, i18nKey string) st
 	}
 	return i.Title
 }
+
+func (items GenericItems) GetCount() map[string]int {
+	filmCount := 0
+	tvSeasonCount := 0
+	for _, i := range items {
+		if i.ItemType == "film" {
+			filmCount += 1
+		} else if i.ItemType == "tvseason" {
+			tvSeasonCount += 1
+		}
+
+	}
+	return map[string]int{
+		"film":     filmCount,
+		"tvseason": tvSeasonCount,
+	}
+}

--- a/kibble/models/generic_item_test.go
+++ b/kibble/models/generic_item_test.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCount(t *testing.T) {
+	tests := map[string]struct {
+		input  GenericItems
+		sep    string
+		expect map[string]int
+	}{
+		"empty":          {input: []GenericItem{}, expect: map[string]int{"film": 0, "tvseason": 0}},
+		"single film":    {input: []GenericItem{GenericItem{ItemType: "film"}}, expect: map[string]int{"film": 1, "tvseason": 0}},
+		"single season":  {input: []GenericItem{GenericItem{ItemType: "tvseason"}}, expect: map[string]int{"film": 0, "tvseason": 1}},
+		"multiple items": {input: []GenericItem{GenericItem{ItemType: "film"}, GenericItem{ItemType: "tvseason"}}, expect: map[string]int{"film": 1, "tvseason": 1}},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tc.input.GetCount()
+			assert.Equal(t, got, tc.expect, name)
+		})
+	}
+}

--- a/kibble/models/taxonomy.go
+++ b/kibble/models/taxonomy.go
@@ -149,20 +149,3 @@ func (slice GenericItems) Less(i, j int) bool {
 func (slice GenericItems) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
-
-func (items GenericItems) GetCount() map[string]int {
-	filmCount := 0
-	tvSeasonCount := 0
-	for _, i := range items {
-		if i.ItemType == "film" {
-			filmCount += 1
-		} else if i.ItemType == "tvseason" {
-			tvSeasonCount += 1
-		}
-
-	}
-	return map[string]int{
-		"film":     filmCount,
-		"tvseason": tvSeasonCount,
-	}
-}


### PR DESCRIPTION
This will be used on the bundles page to indicate the number of films and season
in a bundle.

[ADO Card](https://dev.azure.com/S72/SHIFT72/_boards/board/t/Web%20team/Stories/?workitem=7964)
