### PR TITLE
batch index and gathering data on tv shows / seasons to 300 at a time

### DIFF
--- a/kibble/api/tv.go
+++ b/kibble/api/tv.go
@@ -74,6 +74,11 @@ func AppendAllTVShows(cfg *models.Config, site *models.Site, itemIndex models.It
 func AppendTVSeasons(cfg *models.Config, site *models.Site, slugs []string, itemIndex models.ItemIndex) error {
 
 	sort.Strings(slugs)
+
+	if len(slugs) > 300 {
+		slugs = slugs[:300]
+	}
+
 	ids := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(slugs)), ","), "[]")
 
 	// set index to empty for the items requested


### PR DESCRIPTION
One of our clients was overwhelming the indexing of tv shows. This code will limit to only getting info on 300 seasons at a time (as we currently do with films https://github.com/shift72/kibble/blob/master/kibble/api/films.go#L73).  The function will be called over and over until all seasons are index https://github.com/shift72/kibble/blob/master/kibble/api/site.go#L113 i.e. if theres more than 300 seasons, it will batch the first lot, then there will still be seasons flagged as unresolved until all seasons are done. 