### PR TITLE
Dev mode: nicer HTML injection of error message / live reload

### DIFF
--- a/kibble/api/translations.go
+++ b/kibble/api/translations.go
@@ -44,7 +44,7 @@ func LoadAllTranslations(cfg *models.Config, site *models.Site) error {
 		site.Translations[formatPathLocale(code)] = wholeLanguage
 	}
 
-	log.Infof("Translations Recieved and Parsed")
+	log.Infof("Translations received and parsed")
 	return nil
 }
 


### PR DESCRIPTION
This improves the way that build error notifications and the live reload markup is injected.

Previously, if there was a build error anywhere on the site, the errors got prepended to the HTML response. This resulted in invalid markup and made the site completely unusable in dev mode.

These build errors sometimes happened for relatively minor things, like invalid meta coming back for some items, and may not have a significant impact on the site in a prod build.

Instead, this now looks for the </body> tag and injects any HTML there.

Rather than spamming all the errors, it just sticks in a nice notification toast that goes away after several seconds.

![image](https://github.com/shift72/kibble/assets/98778140/93de4b33-4234-4830-ad99-b3207530cef1)
