### PR TITLE
Add config option to disable launching the browser automatically

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 # Change log
 
 ## [Unreleased]
+ - Improved dev-server error feedback: it now injects an error notification into
+   the end of the HTML body rather than generating invalid HTML on every page.
+   This means you can still use the site even if there's a data error causing 
+   some pages to not render correctly (an issue that can be invisible in prod)
+ - Add option to disable launching browser in dev mode. Setting 
+   `liveReload.launchBrowser = false` in kibble.json will stop it popping open 
+   a new tab every time you restart the dev server.
 
 ## [0.17.5] - 2024-04-24
   - Stable release it deploys

--- a/kibble/config/config.go
+++ b/kibble/config/config.go
@@ -47,6 +47,9 @@ func LoadConfig(runAsAdmin bool, apiKey string, disableCache bool) *models.Confi
 	cfg := models.Config{
 		RunAsAdmin:   runAsAdmin,
 		DisableCache: disableCache,
+		LiveReload: models.LiveReloadConfig{
+			LaunchBrowser: true,
+		},
 	}
 	err = json.Unmarshal(file, &cfg)
 	if err != nil {

--- a/kibble/models/config.go
+++ b/kibble/models/config.go
@@ -38,7 +38,8 @@ type Config struct {
 
 // LiveReloadConfig - configuration options for the live_reloader
 type LiveReloadConfig struct {
-	IgnoredPaths []string `json:"ignoredPaths"`
+	IgnoredPaths  []string `json:"ignoredPaths"`
+	LaunchBrowser bool     `json:"launchBrowser"`
 }
 
 // PrivateConfig - config loaded from

--- a/kibble/render/live_reload.go
+++ b/kibble/render/live_reload.go
@@ -277,14 +277,16 @@ func (live *LiveReload) StartLiveReload(port int32, fn func()) {
 		}
 	}()
 
-	// launch the browser
-	go func() {
+	if live.config.LaunchBrowser {
+		// launch the browser
+		go func() {
 
-		// wait for the channel to be rendered
-		<-rendered
+			// wait for the channel to be rendered
+			<-rendered
 
-		utils.LaunchBrowser(url)
-	}()
+			utils.LaunchBrowser(url)
+		}()
+	}
 
 	// useful to trigger one new reload
 	changesChannel <- true


### PR DESCRIPTION
It can get annoying having kibble pop open a new tab every time you restart the dev server. Usually I've already got a tab open that will refresh, and then once the render finishes it pops open another one. 

Maybe this is a feature just for me, but it can be disabled now in the kibble.json

```json
{
  "liveReload": {
    "launchBrowser": false
  }
}
```

By default, it will open the browser.