### PR TITLE
cli: add --config and --toggle options to override api configs/toggles

### DIFF
--- a/kibble/api/config.go
+++ b/kibble/api/config.go
@@ -51,6 +51,11 @@ func LoadConfig(cfg *models.Config) (models.ServiceConfig, error) {
 			config[k] = v
 		}
 	}
+
+	for k, v := range cfg.ConfigOverrides {
+		config[k] = v
+	}
+
 	return config, nil
 }
 
@@ -58,7 +63,7 @@ func LoadConfig(cfg *models.Config) (models.ServiceConfig, error) {
 func LoadFeatureToggles(cfg *models.Config) (models.FeatureToggles, error) {
 
 	var loaded models.FeatureToggles
-	config := make(models.FeatureToggles)
+	toggles := make(models.FeatureToggles)
 
 	paths := []string{
 		fmt.Sprintf("%s/services/shopping/feature_toggles", cfg.SiteURL),
@@ -79,8 +84,13 @@ func LoadFeatureToggles(cfg *models.Config) (models.FeatureToggles, error) {
 		}
 
 		for k, v := range loaded {
-			config[k] = v
+			toggles[k] = v
 		}
 	}
-	return config, nil
+
+	for k, v := range cfg.ToggleOverrides {
+		toggles[k] = v
+	}
+
+	return toggles, nil
 }

--- a/kibble/cmd/root.go
+++ b/kibble/cmd/root.go
@@ -15,9 +15,9 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
+	logging "github.com/op/go-logging"
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +25,8 @@ var runAsAdmin bool
 var disableCache bool
 var verbose bool
 var apiKey string
+
+var log *logging.Logger
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -38,12 +40,13 @@ for the SHIFT72 Video Platform.`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		log.Errorf("%v", err)
 		os.Exit(-1)
 	}
 }
 
 func init() {
+	log = logging.MustGetLogger("kibble")
 	RootCmd.PersistentFlags().BoolVar(&runAsAdmin, "admin", false, "Render using admin credentials")
 	RootCmd.PersistentFlags().StringVar(&apiKey, "api-key", "", "Api key to authenicate with")
 	RootCmd.PersistentFlags().BoolVar(&disableCache, "disable-cache", false, "Prevent caching")

--- a/kibble/config/config.go
+++ b/kibble/config/config.go
@@ -50,6 +50,8 @@ func LoadConfig(runAsAdmin bool, apiKey string, disableCache bool) *models.Confi
 		LiveReload: models.LiveReloadConfig{
 			LaunchBrowser: true,
 		},
+		ConfigOverrides: map[string]string{},
+		ToggleOverrides: map[string]bool{},
 	}
 	err = json.Unmarshal(file, &cfg)
 	if err != nil {

--- a/kibble/go.mod
+++ b/kibble/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
 	github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
-	github.com/spf13/pflag v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
 	golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/kibble/go.sum
+++ b/kibble/go.sum
@@ -68,6 +68,8 @@ github.com/spf13/cobra v0.0.0-20170929161612-e5f66de850af h1:Qrv36iBHVS2H6QeH+ef
 github.com/spf13/cobra v0.0.0-20170929161612-e5f66de850af/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.0 h1:oaPbdDe/x0UncahuwiPxW1GYJyilRAdsPnq3e1yaPcI=
 github.com/spf13/pflag v1.0.0/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/kibble/models/config.go
+++ b/kibble/models/config.go
@@ -34,6 +34,10 @@ type Config struct {
 	DefaultDateFormat         string                    `json:"defaultDateFormat"`
 	DefaultTimeFormat         string                    `json:"defaultTimeFormat"`
 	CoreTemplateVersion       string                    `json:"coreTemplateVersion"`
+
+	// allows overriding config variables
+	ConfigOverrides map[string]string `json:"configOverrides"`
+	ToggleOverrides map[string]bool   `json:"toggleOverrides"`
 }
 
 // LiveReloadConfig - configuration options for the live_reloader


### PR DESCRIPTION
Lets you override API config and toggle values when running a template render / dev server to help with testing.

```
kibble render --watch --port 8081 --config foo=123 --config bar=456  --toggle test=true
```

You can also specify these in kibble.json

```json
{
  "configOverrides": {
    "foo": "bar"
  },
  "toggleOverrides": {
    "test": true
  }
}
```

Command line args > kibble.json > api

Obviously, this only affects the site template, and any configs/toggles that might get passed through to the frontend JS!

The command line args are only supported on the `render` command, however the kibble.json settings should affect all places in the code that render the site. If you deployed a site with kibble.json overrides, those overrides would be applied to the built site too!